### PR TITLE
Fix generation of repository URLs

### DIFF
--- a/.github/workflows/plugin-checker.yml
+++ b/.github/workflows/plugin-checker.yml
@@ -260,11 +260,11 @@ jobs:
         fi
 
     # Setup python environment
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       if: success()
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     # Setup node environment
     - name: Set up node 16

--- a/scripts/generate_repository.py
+++ b/scripts/generate_repository.py
@@ -187,7 +187,7 @@ with open(os.path.join(project_root, 'config.json')) as f:
 print("  > Setting repo data url".format(repo_json_file))
 print()
 configured_remote_origin = os.popen('git remote get-url --push origin').read()
-repo_path = configured_remote_origin.strip().rstrip(".git").lstrip('git@github.coms:').lstrip('https://github.com/s')
+repo_path = configured_remote_origin.strip().removesuffix(".git").removeprefix('git@github.com:').removeprefix('https://github.com/')
 repo_info['repo_data_directory'] = "https://raw.githubusercontent.com/{}/repo/".format(repo_path)
 repo_info['repo_data_url'] = repo_info['repo_data_directory'] + "repo/repo.json"
 repo_data['repo'] = repo_info


### PR DESCRIPTION
Use `removeprefix` and `removesuffix` from Python 3.9 to fix
repository file generation.

This fixes #136 