### PR TITLE
Add "rename" trigger option to notify_radarr

### DIFF
--- a/source/notify_radarr/changelog.md
+++ b/source/notify_radarr/changelog.md
@@ -1,4 +1,9 @@
 
+**<span style="color:#56adda">0.0.4</span>**
+- Add ability to trigger Radarr file renaming
+- Improve logging
+- Improve error handling for update mode
+
 **<span style="color:#56adda">0.0.3</span>**
 - Improve logging
 - Improve description

--- a/source/notify_radarr/description.md
+++ b/source/notify_radarr/description.md
@@ -16,6 +16,11 @@ Radarr application API key
 Use this mode when you wish to simply trigger a refresh on a movie to re-read a modified file after Unmanic has 
 processed it.
 
+#### <span style="color:blue">Trigger Radarr file renaming</span>
+Only available if the *Trigger movie refresh on task complete* mode is selected.
+
+Trigger Radarr to re-name files according to the defined naming scheme. Useful if you've changed encodings and have these encodings in your name templates.
+
 ##### Import movie on task complete
 Use this mode when you are running Unmanic prior to importing a file into Radarr. 
 This will trigger a download import.

--- a/source/notify_radarr/info.json
+++ b/source/notify_radarr/info.json
@@ -11,5 +11,5 @@
         "on_postprocessor_task_results": 0
     },
     "tags": "radarr",
-    "version": "0.0.3"
+    "version": "0.0.4"
 }


### PR DESCRIPTION
# Pull request

## Description of the pull request

<!--- Provide a short summary of submitted plugin in case PR is a new addition. -->
<!--- If PR is plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
This PR seeks to achieve the following goals:

1. Add the option to have radarr run its built in rename function. Useful when re-encoding files in situations where radarr does file renaming and has encoding information included in the naming format.
2. I wanted some error handling for the new API call and while I was at it I added the same error handling to the refresh call.
3. Swapped the logger lines to "lazy" mode to slightly improve performance. See https://medium.com/swlh/why-it-matters-how-you-log-in-python-1a1085851205.
4. I'm happy to port this change to notify_sonarr once merged.


## CLA

- [X] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the owner of this git project. 
My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [X] I have ensured that my pull request is being opened to merge into the correct branch.
Merging into "official" per https://docs.unmanic.app/docs/development/plugin_repos/creating_a_pull_request
- [ ] (If submitting a new plugin) I have included a copy of the GPL v3.0 [LICENSE](../LICENSE) 
file in my plugin directory.
Not a new plugin.
- [X] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md#opening-pull-requests).
Header already exists :)