### PR TITLE
[comskip] 0.0.7 - add command line option to use nvidia h/w

### DIFF
--- a/source/comskip/changelog.md
+++ b/source/comskip/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.7</span>**
+- Added h/w accelerated comskip option using cuvid
+
 **<span style="color:#56adda">0.0.6</span>**
 - Enabled support for v2 plugin executor
 

--- a/source/comskip/comchap/comchap
+++ b/source/comskip/comchap/comchap
@@ -31,6 +31,7 @@ deletetxt=true
 verbose=false
 lockfile=""
 workdir=""
+usehw=false
 
 while [[ $# -gt 0 ]]
 do
@@ -46,6 +47,10 @@ case $key in
     ;;
     --verbose)
     verbose=true
+    shift
+    ;;
+    --use-hw)
+    usehw=true
     shift
     ;;
     --ffmpeg=*)
@@ -150,7 +155,11 @@ txtfile="$workdir${infile%.*}.txt"
 fi
 
 if [ ! -f "$edlfile" ]; then
-  $comskipPath --ini="$comskipini" "$infile"
+  if [ "$usehw" == false ]; then
+    $comskipPath --ini="$comskipini" "$infile"
+  else
+    $comskipPath --cuvid --ini="$comskipini" "$infile"
+  fi
 
   if [ ! -f "$edlfile" ] ; then
     echo "Error running comskip. EDL File not found: $infile"  1>&3 2>&4 >&2

--- a/source/comskip/comchap/comcut
+++ b/source/comskip/comchap/comcut
@@ -30,6 +30,7 @@ deletelogo=true
 deletetxt=true
 lockfile=""
 workdir=""
+usehw=false
 
 while [[ $# -gt 0 ]]
 do
@@ -41,6 +42,10 @@ case $key in
     ;;
     --keep-meta)
     deletemeta=false
+    shift
+    ;;
+    --use-hw)
+    usehw=true
     shift
     ;;
     --ffmpeg=*)
@@ -139,7 +144,11 @@ fi
 
 
 if [ ! -f "$edlfile" ]; then
-  $comskipPath $comskipoutput --ini="$comskipini" "$infile"
+  if [ "$usehw" == false ]; then
+    $comskipPath $comskipoutput --ini="$comskipini" "$infile"
+  else
+    $comskipPath $comskipoutput --cuvid --ini="$comskipini" "$infile"
+  fi
 fi
 
 start=0

--- a/source/comskip/description.md
+++ b/source/comskip/description.md
@@ -61,5 +61,7 @@ Chapters are still added to the resulting file.
 <br>Ensure you are happy with your Comskip configuration before letting loose on your library.
 </div>
 
+#### <span style="color:blue">Use hardware acceleration for commercial detection</span>
+Uses hardware acceleration for commercial detection - compatible only with Nvidia NVDEC currently.
 
-
+Do not select if you do not have a compatible Nvidia GPU.

--- a/source/comskip/info.json
+++ b/source/comskip/info.json
@@ -14,5 +14,5 @@
         "on_postprocessor_task_results":1
     },
     "tags": "video,pvr,library file test",
-    "version": "0.0.6"
+    "version": "0.0.7"
 }

--- a/source/comskip/plugin.py
+++ b/source/comskip/plugin.py
@@ -42,6 +42,7 @@ class Settings(PluginSettings):
         'config':              '',
         'enable_comchap':      False,
         'enable_comcut':       False,
+        'use_hw':              False,
     }
 
     def __init__(self, *args, **kwargs):
@@ -57,6 +58,7 @@ class Settings(PluginSettings):
             },
             "enable_comchap":      self.__set_enable_comchap_form_settings(),
             "enable_comcut":       self.__set_enable_comcut_form_settings(),
+            "use_hw":              self.__set_use_hw_form_settings(),
         }
 
     def __set_allowed_extensions_form_settings(self):
@@ -85,6 +87,11 @@ class Settings(PluginSettings):
             values["display"] = 'hidden'
         return values
 
+    def __set_use_hw_form_settings(self):
+        values = {
+            "label": "Use h/w accelerated Commercial Skipping",
+        }
+        return values
 
 def file_ends_in_allowed_extensions(path, allowed_extensions):
     """
@@ -198,13 +205,24 @@ def build_comskip_args(abspath, settings):
     config_file = comskip_config_file(settings)
     file_dirname = os.path.dirname(abspath)
     file_sans_ext = os.path.splitext(os.path.basename(abspath))[0]
-    return [
-        'comskip',
-        '--ini={}'.format(config_file),
-        '--output={}'.format(file_dirname),
-        '--output-filename={}'.format(file_sans_ext),
-        abspath
-    ]
+    use_hw = settings.get_setting('use_hw')
+    if not use_hw:
+        return [
+            'comskip',
+            '--ini={}'.format(config_file),
+            '--output={}'.format(file_dirname),
+            '--output-filename={}'.format(file_sans_ext),
+            abspath
+        ]
+    else:
+        return [
+            'comskip',
+            '--cuvid',
+            '--ini={}'.format(config_file),
+            '--output={}'.format(file_dirname),
+            '--output-filename={}'.format(file_sans_ext),
+            abspath
+        ]
 
 
 def build_comchap_args(abspath, file_out, settings):
@@ -213,15 +231,28 @@ def build_comchap_args(abspath, file_out, settings):
     # Ensure comchap is executable
     st = os.stat(comchap_path)
     os.chmod(comchap_path, st.st_mode | stat.S_IEXEC)
-    args = [
-        comchap_path,
-        '--comskip-ini={}'.format(config_file),
-        '--keep-edl',
-        '--keep-meta',
-        '--verbose',
-        abspath,
-        file_out,
-    ]
+    use_hw = settings.get_setting('use_hw')
+    if not use_hw:
+        args = [
+            comchap_path,
+            '--comskip-ini={}'.format(config_file),
+            '--keep-edl',
+            '--keep-meta',
+            '--verbose',
+            abspath,
+            file_out,
+        ]
+    else:
+        args = [
+            comchap_path,
+            '--comskip-ini={}'.format(config_file),
+            '--use-hw',
+            '--keep-edl',
+            '--keep-meta',
+            '--verbose',
+            abspath,
+            file_out,
+        ]
     return args
 
 
@@ -231,14 +262,28 @@ def build_comcut_args(abspath, file_out, settings):
     # Ensure comcut is executable
     st = os.stat(comcut_path)
     os.chmod(comcut_path, st.st_mode | stat.S_IEXEC)
-    args = [
-        comcut_path,
-        '--comskip-ini={}'.format(config_file),
-        '--keep-edl',
-        '--keep-meta',
-        abspath,
-        file_out,
-    ]
+    use_hw = settings.get_setting('use_hw')
+    if not use_hw:
+        args = [
+            comchap_path,
+            '--comskip-ini={}'.format(config_file),
+            '--keep-edl',
+            '--keep-meta',
+            '--verbose',
+            abspath,
+            file_out,
+        ]
+    else:
+        args = [
+            comchap_path,
+            '--comskip-ini={}'.format(config_file),
+            '--use-hw',
+            '--keep-edl',
+            '--keep-meta',
+            '--verbose',
+            abspath,
+            file_out,
+        ]
     return args
 
 


### PR DESCRIPTION
Adds options to use h/w decoding.  the ini file option "hardware_decode" doesn't seem to leverage nvidia gpu, but there's a --cuvid command line option that does.  This PR adds options to the comskip plugin to optionally "use h/w" for the decode - a noted in the description says to only use it if you have an nvidia GPU.