### PR TITLE
[notify_jellyfin] 0.0.2

### DIFF
--- a/source/notify_jellyfin/changelog.md
+++ b/source/notify_jellyfin/changelog.md
@@ -1,3 +1,6 @@
 
+**<span style="color:#56adda">0.0.2</span>**
+- add check for connection error so plugin doesn't fail due to connection/authorization errors - otherwise plugin will prevent post processing from continuing 
+
 **<span style="color:#56adda">0.0.1</span>**
 - Initial version - based on notify_plex 0.0.5 by Josh.5

--- a/source/notify_jellyfin/info.json
+++ b/source/notify_jellyfin/info.json
@@ -15,5 +15,5 @@
         "on_postprocessor_task_results": 0
     },
     "tags": "post-processor",
-    "version": "0.0.1"
+    "version": "0.0.2"
 }

--- a/source/notify_jellyfin/plugin.py
+++ b/source/notify_jellyfin/plugin.py
@@ -37,11 +37,15 @@ class Settings(PluginSettings):
 
 def update_jellyfin(jellyfin_url, jellyfin_apikey):
     headers = {'X-MediaBrowser-Token': jellyfin_apikey}
-    r = requests.post(jellyfin_url + "/Library/Refresh", headers=headers)
+    try:
+        r = requests.post(jellyfin_url + "/Library/Refresh", headers=headers)
+    except (ConnectionRefusedError, requests.exceptions.ConnectionError) as error:
+        logger.error("Error Connecting to Jellyfin - unable to reach or unauthorized")
+        
     if r.status_code == 204:
-        logger.info("Notifying Jellyfin ({}) to update its library.".format(jellyfin_url))
+        logger.info("Notifying Jellyfin ('{}') to update its library.".format(jellyfin_url))
     else:
-        logger.error("Error notifying Jellyfin - Error Code:({}).".format(r.status_code))
+        logger.error("Error notifying Jellyfin - Error Code:('{}').".format(r.status_code))
 
 def on_postprocessor_task_results(data):
     """


### PR DESCRIPTION
add check for connection/authorization error so that plugin failure doesn't prevent post processing from continuing.  Connection Error message written to logger.error.