### PR TITLE
Remove slashes from subtitle filenames

### DIFF
--- a/source/extract_srt_subtitles_to_files/plugin.py
+++ b/source/extract_srt_subtitles_to_files/plugin.py
@@ -53,8 +53,8 @@ class PluginStreamMapper(StreamMapper):
         if not subtitle_tag:
             subtitle_tag = "{}.{}".format(subtitle_tag, stream_info.get('index'))
 
-        # Ensure subtitle tag does not contain whitespace
-        subtitle_tag = re.sub('\s', '-', subtitle_tag)
+        # Ensure subtitle tag does not contain whitespace or slashes
+        subtitle_tag = re.sub('\s|/|\\', '-', subtitle_tag)
 
         self.sub_streams.append(
             {


### PR DESCRIPTION
If a subtitle stream name contains slashes, for example `/`, the extract plugin fails when attempting to run

### Cut down log output

```
RUNNER:

Extract text subtitle streams to SRT files [Pass #1]

Executing plugin runner... Please wait
Plugin runner requested for a command to be executed by Unmanic

COMMAND:

ffmpeg -hide_banner -loglevel info -i /tmp/unmanic/unmanic_file_conversion-viyar-1695211338/file-viyar-1695211338-WORKING-2-1.mkv -strict -2 -max_muxing_queue_size 4096 -map 0:s:0 -y file.eng.Songs/Signs.srt

LOG:

Input #0, matroska,webm, from 'file-viyar-1695211338-WORKING-2-1.mkv':
   Stream #0:3(eng): Subtitle: subrip (default)
     Metadata:
       title : Songs/Signs
       BPS : 25
       BPS-eng : 25
       DURATION-eng : 00:23:22.260000000
       NUMBER_OF_FRAMES: 69
       NUMBER_OF_FRAMES-eng: 69
       NUMBER_OF_BYTES : 4522
       NUMBER_OF_BYTES-eng: 4522
       _STATISTICS_WRITING_APP: mkvmerge v9.2.0 ('Photograph') 64bit
       _STATISTICS_WRITING_APP-eng: mkvmerge v9.2.0 ('Photograph') 64bit
       _STATISTICS_WRITING_DATE_UTC: 2016-06-05 04:10:20
       _STATISTICS_WRITING_DATE_UTC-eng: 2016-06-05 04:10:20
       _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
       _STATISTICS_TAGS-eng: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
       ENCODER : Lavc58.134.100 subrip
       DURATION : 00:23:36.100000000

file.eng.Songs/Signs.srt: No such file or directory
```