### PR TITLE
Correct regex escaping for renaming subtitle tags

### DIFF
--- a/source/extract_srt_subtitles_to_files/info.json
+++ b/source/extract_srt_subtitles_to_files/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 2
     },
     "tags": "subtitle,ffmpeg",
-    "version": "0.0.9"
+    "version": "0.0.10"
 }

--- a/source/extract_srt_subtitles_to_files/plugin.py
+++ b/source/extract_srt_subtitles_to_files/plugin.py
@@ -113,7 +113,7 @@ class PluginStreamMapper(StreamMapper):
             subtitle_tag = "{}.{}".format(subtitle_tag, stream_info.get('index'))
 
         # Ensure subtitle tag does not contain whitespace or slashes
-        subtitle_tag = re.sub('\s|/|\\', '-', subtitle_tag)
+        subtitle_tag = re.sub('\s|/|\\\\', '-', subtitle_tag)
 
         self.sub_streams.append(
             {


### PR DESCRIPTION
Credit for this goes to https://github.com/bambanah

The online python tester I used didn't correctly check the escaping of the `\`, so they actually need to be doubled up (see: https://github.com/Unmanic/unmanic-plugins/pull/349#discussion_r1343462256).

I have tested this with a Python REPL and can confirm that the previous code does have an issue and the updated code works.