### PR TITLE
[comskip] 0.0.8

### DIFF
--- a/source/comskip/changelog.md
+++ b/source/comskip/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.8</span>**
+- fix comcut_path in build_comcut_args - was wrong due to copy/paste error
+
 **<span style="color:#56adda">0.0.7</span>**
 - Added h/w accelerated comskip option using cuvid
 

--- a/source/comskip/info.json
+++ b/source/comskip/info.json
@@ -14,5 +14,5 @@
         "on_postprocessor_task_results":1
     },
     "tags": "video,pvr,library file test",
-    "version": "0.0.7"
+    "version": "0.0.8"
 }

--- a/source/comskip/plugin.py
+++ b/source/comskip/plugin.py
@@ -265,22 +265,20 @@ def build_comcut_args(abspath, file_out, settings):
     use_hw = settings.get_setting('use_hw')
     if not use_hw:
         args = [
-            comchap_path,
+            comcut_path,
             '--comskip-ini={}'.format(config_file),
             '--keep-edl',
             '--keep-meta',
-            '--verbose',
             abspath,
             file_out,
         ]
     else:
         args = [
-            comchap_path,
+            comcut_path,
             '--comskip-ini={}'.format(config_file),
             '--use-hw',
             '--keep-edl',
             '--keep-meta',
-            '--verbose',
             abspath,
             file_out,
         ]


### PR DESCRIPTION
build_comcut_args was referencing wrong path variable due to a copy paste error i made when i updated v.0.0.6 to v0.0.7.  i pasted comchap_path from build_comchap_args when it should have remained comcut_path.  Also, the original plugin didn't have the verbose option in the build_comcut_args function, so i removed that too.