### PR TITLE
Video-File-Size-Plugin-Ignore-Non-Video-Files

### DIFF
--- a/source/ignore_under_size/plugin.py
+++ b/source/ignore_under_size/plugin.py
@@ -27,7 +27,7 @@ import logging
 from unmanic.libs.unplugins.settings import PluginSettings
 
 # Configure plugin logger
-logger = logging.getLogger("Unmanic.Plugin.ignore_under_size")
+logger = logging.getLogger("Unmanic.Plugin.ignore_video_file_under_size")
 
 
 class Settings(PluginSettings):

--- a/source/ignore_video_file_under_size/changelog.md
+++ b/source/ignore_video_file_under_size/changelog.md
@@ -1,2 +1,5 @@
+**<span style="color:#56adda">0.0.2</span>**
+- Skip checking non-video files
+
 **<span style="color:#56adda">0.0.1</span>**
 - Initial version

--- a/source/ignore_video_file_under_size/info.json
+++ b/source/ignore_video_file_under_size/info.json
@@ -4,7 +4,7 @@
         1,
         2
     ],
-    "description": "Ignore video files under the configured size",
+    "description": "Ignore video files under the configured size per hour per resolution.",
     "icon": "https://raw.githubusercontent.com/Unmanic/unmanic-plugins/official/source/ignore_under_size/icon.png",
     "id": "ignore_video_file_under_size",
     "name": "Ignore video files under size",

--- a/source/ignore_video_file_under_size/plugin.py
+++ b/source/ignore_video_file_under_size/plugin.py
@@ -28,6 +28,7 @@ from enum import Enum
 import humanfriendly
 import subprocess
 import logging
+import mimetypes
 from unmanic.libs.unplugins.settings import PluginSettings
 
 # Configure plugin logger
@@ -150,7 +151,7 @@ def on_library_management_file_test(data):
     """
     file_path = data.get('path')
     logger.debug("Checking file %s", file_path)
-    file_mime_type = subprocess.check_output(["file", "--mime-type", file_path], text=True)
+    file_mime_type = mimetypes.guess_type(file_path)[0]
     if "video" not in file_mime_type:
         file_extension = os.path.splitext(file_path)[1]
         if file_extension in ["mkv", "mp4", "mov", "avi", "wmv", "flv", "avchd"]:

--- a/source/ignore_video_file_under_size/plugin.py
+++ b/source/ignore_video_file_under_size/plugin.py
@@ -148,6 +148,18 @@ def on_library_management_file_test(data):
     :return:
 
     """
+    file_path = data.get('path')
+    logger.debug("Checking file %s", file_path)
+    file_mime_type = subprocess.check_output(["file", "--mime-type", file_path], text=True)
+    if "video" not in file_mime_type:
+        file_extension = os.path.splitext(file_path)[1]
+        if file_extension in ["mkv", "mp4", "mov", "avi", "wmv", "flv", "avchd"]:
+            raise AssertionError(f"File {file_path} was a known video type "
+                                 f"but mime type was {file_mime_type} was not recognized")
+        logger.debug("File with extension %s is not a video file (was %s), skipping",
+                     file_extension, file_mime_type)
+        return data
+
     # Configure settings object (maintain compatibility with v1 plugins)
     if data.get('library_id'):
         settings = Settings(library_id=data.get('library_id'))
@@ -163,7 +175,6 @@ def on_library_management_file_test(data):
     if minimum_file_size_per_second == 0:
         return data
 
-    file_path = data.get('path')
     video_data = get_video_data(file_path)
     actual_file_size_per_second = get_time_normalized_file_size(file_path, video_data)
     minimum_file_size_per_second = normalize_by_resolution(minimum_file_size_per_second, video_data)

--- a/source/ignore_video_file_under_size/requirements.txt
+++ b/source/ignore_video_file_under_size/requirements.txt
@@ -1,1 +1,1 @@
-humanfriendly>=9.1
+humanfriendly>=10.0


### PR DESCRIPTION
When running the plugin on my full library, I found two things:
1. The plugin wastes time checking non video files. Also, surprisingly `.nfo` files return both an (incorrect) duration and a resolution when probed with ffprobe.
1. I have some corrupted video files that caused the plugin to throw an exception. It still will, but it'll happen earlier and be more informative.
