### PR TITLE
Fix add_extra_stereo_audio causing exception when the audio stream has no language tag. Added option to generate stream if no language

### DIFF
--- a/source/add_extra_stereo_audio/changelog.md
+++ b/source/add_extra_stereo_audio/changelog.md
@@ -1,6 +1,6 @@
 
 **<span style="color:#56adda">0.0.10</span>**
-- Fiexed an issue where if thhe audio stream had no language tag the debug logger would cause an exception
+- Fixed an issue where if the audio stream had no language tag the debug logger would cause an exception
 - Added ability to generate an audio stream for video files if no language tags are present in the audio streams
 
 **<span style="color:#56adda">0.0.9</span>**

--- a/source/add_extra_stereo_audio/changelog.md
+++ b/source/add_extra_stereo_audio/changelog.md
@@ -1,4 +1,8 @@
 
+**<span style="color:#56adda">0.0.10</span>**
+- Fiexed an issue where if thhe audio stream had no language tag the debug logger would cause an exception
+- Added ability to generate an audio stream for video files if no language tags are present in the audio streams
+
 **<span style="color:#56adda">0.0.9</span>**
 - unspecified stream parameters now can only be channels and codec, language must be specified
 

--- a/source/add_extra_stereo_audio/description.md
+++ b/source/add_extra_stereo_audio/description.md
@@ -44,6 +44,9 @@ Check if you wish to remove the identified/specified multichannel audio stream -
 #### <span style="color:blue">new stereo audio to be the default audio upon playing</span>
 Check if you wish to make the new stereo audio be the default audio - if unchecked, default audio is not changed
 
+#### <span style="color:blue">Create sterero audio stream if no valid language tags</span>
+Check if you wish to generate a stereo audio track even if there are no valid lanugage tags - otherwise valid language tags are required.
+
 :::note
 This plugin will create a stereo aac or libfdk_aac stream as an additional stereo stream.
 It will search for the first stream matching the search parameters and encode that as an
@@ -52,8 +55,8 @@ additional 2 channel stereo audio using aac or, if selected, libfdk_aac (ffmpeg 
 If either channels or codec name search parameters are left blank, this plugin will select the first stream with a
 number of audio channels > 4 and language matching specified language and encode that as the additional 2 channel stereo stream
 
-For this plugin to work successfully, audio streams must have proper language tags - particularly
-the stream that is to be re-encoded as an additional stereo stream
+For this plugin to work best, audio streams must have proper language tags - particularly
+the stream that is to be re-encoded as an additional stereo stream. If you wish for audio streams to be generated where no language tags are present, enable the force_if_no_lang option.
 
 If you opt to remove the original multichannel audio stream, the stereo audio stream will occupy it's
 place and all other streams will be left intact

--- a/source/add_extra_stereo_audio/info.json
+++ b/source/add_extra_stereo_audio/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,encoder,ffmpeg,library file test",
-    "version": "0.0.9"
+    "version": "0.0.10"
 }

--- a/source/add_extra_stereo_audio/plugin.py
+++ b/source/add_extra_stereo_audio/plugin.py
@@ -74,6 +74,7 @@ def stream_to_stereo_encode(stream_language, channels, codec_name, probe_streams
     stream = audio_stream
     for  i in range(0, len(probe_streams)):
         if "codec_type" in probe_streams[i] and probe_streams[i]["codec_type"] == "audio":
+            if "tags" in probe_streams[i] and "title" in probe_streams[i]["tags"] and probe_streams[i]["tags"]["title"] == 'Commentary':
                 continue
         try:
             if "tags" in probe_streams[i] and "language" in probe_streams[i]["tags"] and probe_streams[i]["codec_name"] == "aac" and probe_streams[i]["channels"] == 2 and probe_streams[i]["channel_layout"] == "stereo" and probe_streams[i]["tags"]["language"] == stream_language: return stream


### PR DESCRIPTION
I had an issue where some video files had no language tag for their audio streams and add_extra_stereo_pair was throwing an exception. I have fixed the issue where an exception is thrown (see the debug.log statement)

I have added a configuration option to generate if there is an audio stream that matches the other requirements but has no language tag also.