### PR TITLE
Pr ignore video file under size

### DIFF
--- a/source/ignore_video_file_under_size/changelog.md
+++ b/source/ignore_video_file_under_size/changelog.md
@@ -1,3 +1,7 @@
+
+**<span style="color:#56adda">0.0.3</span>**
+- add option to read duration from format section of ffprobe output
+
 **<span style="color:#56adda">0.0.2</span>**
 - Skip checking non-video files
 

--- a/source/ignore_video_file_under_size/info.json
+++ b/source/ignore_video_file_under_size/info.json
@@ -15,5 +15,5 @@
         "on_library_management_file_test": 2
     },
     "tags": "library file test",
-    "version": "0.0.2"
+    "version": "0.0.3"
 }

--- a/source/ignore_video_file_under_size/plugin.py
+++ b/source/ignore_video_file_under_size/plugin.py
@@ -89,6 +89,8 @@ class VideoData:
                 self.height = stream_data["height"]
             if "duration" in stream_data:
                 self.duration = float(stream_data["duration"])
+            elif "format" in json.loads(data) and "duration" in json.loads(data)["format"]:
+                self.duration = float(format_data["duration"])
 
         if not self.width:
             raise AssertionError("Unable to determine video width")
@@ -104,7 +106,7 @@ def get_video_data(path: str) -> VideoData:
         args=[
             "ffprobe",
             "-v", "error",
-            "-show_entries", "stream=duration,width,height",
+            "-show_entries", "stream=duration,width,height:format=duration",
             "-print_format", "json",
             path
         ],

--- a/source/ignore_video_file_under_size/plugin.py
+++ b/source/ignore_video_file_under_size/plugin.py
@@ -90,7 +90,7 @@ class VideoData:
             if "duration" in stream_data:
                 self.duration = float(stream_data["duration"])
             elif "format" in json.loads(data) and "duration" in json.loads(data)["format"]:
-                self.duration = float(format_data["duration"])
+                self.duration = float(json.loads(data)["format"]["duration"])
 
         if not self.width:
             raise AssertionError("Unable to determine video width")


### PR DESCRIPTION
Added fix to allow video duration to be obtained from ffprobe format section if streams section is void of duration value.