### PR TITLE
Pr add extra stereo audio

### DIFF
--- a/source/add_extra_stereo_audio/changelog.md
+++ b/source/add_extra_stereo_audio/changelog.md
@@ -1,4 +1,20 @@
 
+**<span style="color:#56adda">0.0.12</span>**
+- fix stream_to_stereo_encode so it doesn't identify incorrect stream in case of files with mixture of tagged and untagged languages
+
+**<span style="color:#56adda">0.0.12</span>**
+- make commentary check a substring test
+- added missing language check in case where channels or codec_name are left blank
+
+**<span style="color:#56adda">0.0.11</span>**
+- add option to move stereo stream to first audio stream
+- remove setting of add to task list of False so subsequent plugins will execute
+- add iso639 module to get language name from code
+- add metadata stream title to stereo stream based on language, codec, and "STEREO"
+
+**<span style="color:#56adda">0.0.10</span>**
+- fix stream to encode to guard against streams with no audio language tags
+
 **<span style="color:#56adda">0.0.9</span>**
 - unspecified stream parameters now can only be channels and codec, language must be specified
 

--- a/source/add_extra_stereo_audio/changelog.md
+++ b/source/add_extra_stereo_audio/changelog.md
@@ -1,5 +1,5 @@
 
-**<span style="color:#56adda">0.0.12</span>**
+**<span style="color:#56adda">0.0.13</span>**
 - fix stream_to_stereo_encode so it doesn't identify incorrect stream in case of files with mixture of tagged and untagged languages
 
 **<span style="color:#56adda">0.0.12</span>**

--- a/source/add_extra_stereo_audio/info.json
+++ b/source/add_extra_stereo_audio/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,encoder,ffmpeg,library file test",
-    "version": "0.0.9"
+    "version": "0.0.13"
 }

--- a/source/add_extra_stereo_audio/requirements.txt
+++ b/source/add_extra_stereo_audio/requirements.txt
@@ -1,0 +1,1 @@
+python-iso639


### PR DESCRIPTION
number of fixes/improvements based on feedback & i have been accumulating them and releasing them in my private repo:

- avoid streams with no audio language tags
- add option to move stereo stream to first audio stream
- remove setting of add to task list of False so subsequent plugins will execute
- add python-iso639 module to get actual language name from code in order to add a metadata title to stream so that added stream has a title different than the original multichannel stream.  helpful for those looking at stream detail in media players