### PR TITLE
Update DataTables package in preparation of dark theme

### DIFF
--- a/source/file_size_metrics/changelog.md
+++ b/source/file_size_metrics/changelog.md
@@ -1,3 +1,5 @@
+**<span style="color:#56adda">0.0.9</span>**
+- Update DataTables plugin in preparation of supporting dark mode
 
 **<span style="color:#56adda">0.0.8</span>**
 - Update Plugin for Unmanic v2 PluginHandler compatibility

--- a/source/file_size_metrics/info.json
+++ b/source/file_size_metrics/info.json
@@ -1,20 +1,15 @@
 {
-    "author": "Josh.5",
-    "compatibility": [
-        1,
-        2
-    ],
-    "description": "Aggregate changes in file size metrics for processed files and add a data panel for displaying the results.",
-    "icon": "https://raw.githubusercontent.com/Josh5/unmanic.plugin.file_size_metrics/master/icon.png",
-    "id": "file_size_metrics",
-    "name": "File Size Metrics Data Panel",
-    "platform": [
-        "all"
-    ],
-    "priorities": {
-        "on_worker_process": 1,
-        "on_postprocessor_task_results": 0
-    },
-    "tags": "data panel",
-    "version": "0.0.8"
+  "author": "Josh.5, EspadaV8",
+  "compatibility": [1, 2],
+  "description": "Aggregate changes in file size metrics for processed files and add a data panel for displaying the results.",
+  "icon": "https://raw.githubusercontent.com/Josh5/unmanic.plugin.file_size_metrics/master/icon.png",
+  "id": "file_size_metrics",
+  "name": "File Size Metrics Data Panel",
+  "platform": ["all"],
+  "priorities": {
+    "on_worker_process": 1,
+    "on_postprocessor_task_results": 0
+  },
+  "tags": "data panel",
+  "version": "0.0.9"
 }

--- a/source/file_size_metrics/package-lock.json
+++ b/source/file_size_metrics/package-lock.json
@@ -5,28 +5,38 @@
   "packages": {
     "": {
       "dependencies": {
-        "datatables": "^1.10.18",
-        "highcharts": "^9.2.2",
-        "jquery": "^3.6.0",
+        "datatables.net-dt": "^1.13.8",
+        "highcharts": "^11.3.0",
+        "jquery": "^3.7.1",
         "vendor-copy": "^3.0.1"
       }
     },
-    "node_modules/datatables": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.18.tgz",
-      "integrity": "sha512-ntatMgS9NN6UMpwbmO+QkYJuKlVeMA2Mi0Gu/QxyIh+dW7ZjLSDhPT2tWlzjpIWEkDYgieDzS9Nu7bdQCW0sbQ==",
+    "node_modules/datatables.net": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
+      "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
       "dependencies": {
         "jquery": ">=1.7"
       }
     },
+    "node_modules/datatables.net-dt": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.8.tgz",
+      "integrity": "sha512-/ZPzr1hQ+domerlg/MbcQHqeeqxK9fsZmpRs1YeKxsdfr+UyHQTUiiOO7RqekppSLc7MPqxGnzKkCX9vAgqm0w==",
+      "dependencies": {
+        "datatables.net": "1.13.8",
+        "jquery": ">=1.7"
+      }
+    },
     "node_modules/highcharts": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.2.2.tgz",
-      "integrity": "sha512-OMEdFCaG626ES1JEcKAvJTpxAOMuchy0XuAplmnOs0Yu7NMd2RMfTLFQ2fCJOxo3ubSdm/RVQwKAWC+5HYThnw=="
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.3.0.tgz",
+      "integrity": "sha512-Dk+Qfk/xit8KnXKPDxmcVcq48ZlcVSq7oYJR5VZlAVWnJ0BY3JFFi1GOvgSNUzlh2wzsfenihWpkAkWoag4Xqg=="
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "node_modules/ncp": {
       "version": "2.0.0",
@@ -52,22 +62,32 @@
     }
   },
   "dependencies": {
-    "datatables": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.18.tgz",
-      "integrity": "sha512-ntatMgS9NN6UMpwbmO+QkYJuKlVeMA2Mi0Gu/QxyIh+dW7ZjLSDhPT2tWlzjpIWEkDYgieDzS9Nu7bdQCW0sbQ==",
+    "datatables.net": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
+      "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
       "requires": {
         "jquery": ">=1.7"
       }
     },
+    "datatables.net-dt": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.8.tgz",
+      "integrity": "sha512-/ZPzr1hQ+domerlg/MbcQHqeeqxK9fsZmpRs1YeKxsdfr+UyHQTUiiOO7RqekppSLc7MPqxGnzKkCX9vAgqm0w==",
+      "requires": {
+        "datatables.net": "1.13.8",
+        "jquery": ">=1.7"
+      }
+    },
     "highcharts": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.2.2.tgz",
-      "integrity": "sha512-OMEdFCaG626ES1JEcKAvJTpxAOMuchy0XuAplmnOs0Yu7NMd2RMfTLFQ2fCJOxo3ubSdm/RVQwKAWC+5HYThnw=="
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.3.0.tgz",
+      "integrity": "sha512-Dk+Qfk/xit8KnXKPDxmcVcq48ZlcVSq7oYJR5VZlAVWnJ0BY3JFFi1GOvgSNUzlh2wzsfenihWpkAkWoag4Xqg=="
     },
     "jquery": {
-      "version": "3.6.0",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "ncp": {
       "version": "2.0.0",

--- a/source/file_size_metrics/package.json
+++ b/source/file_size_metrics/package.json
@@ -3,15 +3,19 @@
     "build": "vendor-copy"
   },
   "dependencies": {
-    "datatables": "^1.10.18",
-    "highcharts": "^9.2.2",
-    "jquery": "^3.6.0",
+    "datatables.net-dt": "^1.13.8",
+    "highcharts": "^11.3.0",
+    "jquery": "^3.7.1",
     "vendor-copy": "^3.0.1"
   },
   "vendorCopy": [
     {
-      "from": "node_modules/datatables",
-      "to": "static/vendor/datatables"
+      "from": "node_modules/datatables.net",
+      "to": "static/vendor/datatables.net"
+    },
+    {
+      "from": "node_modules/datatables.net-dt",
+      "to": "static/vendor/datatables.net-dt"
     },
     {
       "from": "node_modules/jquery",

--- a/source/file_size_metrics/static/index.html
+++ b/source/file_size_metrics/static/index.html
@@ -7,17 +7,20 @@
     <link rel="shortcut icon" href="static/favicon.ico">
 
     <link rel="stylesheet" type="text/css"
-          href="./static/vendor/datatables/media/css/jquery.dataTables.min.css?{cache_buster}">
+          href="./static/vendor/datatables.net-dt/css/jquery.dataTables.min.css?{cache_buster}">
 
     <style>
         .hidden {
             display: none;
         }
 
+        table.dataTable {
+            background-color: #ffffff;
+        }
+
         table.dataTable td {
             word-break: break-word;
         }
-
 
         * {
             box-sizing: border-box;
@@ -219,7 +222,7 @@
 
     <hr>
 
-    <table id="history_completed_tasks_table" class="dataTable" style="width:100%">
+    <table id="history_completed_tasks_table" class="dataTable display" style="width:100%">
         <thead>
         <tr>
             <!--Headers are overwritten in JS datatable config-->
@@ -260,7 +263,7 @@
 
 <!--DATATABLE-->
 <script type="text/javascript"
-        src="./static/vendor/datatables/media/js/jquery.dataTables.min.js?{cache_buster}"></script>
+        src="./static/vendor/datatables.net/js/jquery.dataTables.min.js?{cache_buster}"></script>
 
 <!--CHARTS-->
 <script type="text/javascript" src="./static/vendor/highcharts/highcharts.js?{cache_buster}"></script>


### PR DESCRIPTION
I'm working on adding dark theme support for the data panel plugin. Part of that requires updating DataTables to 1.13 where they added support for dark mode

I didn't want to do all the updates at once, since the MR would be huge, so I'm breaking it down into smaller MRs. Part 1 of that is to just update the DataTables package.

I've tested it using my own plugin repo, and the UI is basically the same as it was previously.