### PR TITLE
Add dark theme support to File Size Metrics plugin

### DIFF
--- a/source/file_size_metrics/changelog.md
+++ b/source/file_size_metrics/changelog.md
@@ -1,3 +1,6 @@
+**<span style="color:#56adda">0.0.10</span>**
+- Initial version of dark mode support
+
 **<span style="color:#56adda">0.0.9</span>**
 - Update DataTables plugin in preparation of supporting dark mode
 

--- a/source/file_size_metrics/info.json
+++ b/source/file_size_metrics/info.json
@@ -11,5 +11,5 @@
     "on_postprocessor_task_results": 0
   },
   "tags": "data panel",
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/source/file_size_metrics/static/css/style.css
+++ b/source/file_size_metrics/static/css/style.css
@@ -1,0 +1,180 @@
+.light {
+  --q-card-head: #f5f5f5;
+  --q-card-head-hover: #e7e7e7;
+  --q-card: #ffffff;
+  --q-page: #ffffff;
+  --q-primary: #002e5c;
+  --q-secondary: #009fdd;
+  --q-text: #000000;
+  --q-warning: #f2c037;
+}
+
+.dark {
+  --q-card-head: #212121;
+  --q-card-head-hover: #383838;
+  --q-card: #181818;
+  --q-page: #121212;
+  --q-primary: #009fdd;
+  --q-secondary: #002e5c;
+  --q-text: #ffffff;
+  --q-warning: #b5902a;
+}
+
+.hidden {
+  display: none;
+}
+
+table.dataTable td {
+  word-break: break-word;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background-color: var(--q-page);
+  color: var(--q-text);
+}
+
+/* Float four columns side by side */
+.column {
+  float: left;
+  padding: 0 10px;
+  width: 50%;
+}
+
+/* Remove extra left and right margins, due to padding */
+.row {
+  margin: 0 -5px;
+}
+
+/* Clear floats after the columns */
+.row:after {
+  clear: both;
+  content: "";
+  display: table;
+}
+
+/* Responsive columns */
+@media screen and (max-width: 600px) {
+  .column {
+    display: block;
+    margin-bottom: 20px;
+    width: 100%;
+  }
+}
+
+/*Cards*/
+.card {
+  background-color: var(--q-card);
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  text-align: center;
+}
+
+.collapsible {
+  background-color: var(--q-card-head);
+  border: none;
+  color: var(--q-primary);
+  cursor: pointer;
+  font-size: 15px;
+  height: 35px;
+  outline: none;
+  padding-left: 18px;
+  padding-right: 18px;
+  text-align: left;
+  width: 100%;
+}
+
+button.collapsible::after {
+  color: var(--q-text);
+  content: "\2212";
+  float: right;
+  font-weight: bold;
+  margin-left: 5px;
+}
+
+button.collapsible.active::after {
+  content: "\002B";
+}
+
+.active,
+.collapsible:hover {
+  background-color: var(--q-card-head-hover);
+}
+
+.content {
+  background-color: var(--q-card);
+  display: none;
+  overflow: hidden;
+  padding: 0 18px;
+}
+
+/*Back to top*/
+.top-of-page-link svg {
+  -webkit-filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.3));
+  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.3));
+}
+
+.top-of-page-link {
+  bottom: 0.2rem;
+  position: fixed;
+  right: 1rem;
+  transition: 0.2s;
+  z-index: 15;
+}
+
+/*Custom*/
+.car-header {
+  display: block;
+  height: 100px;
+  margin-top: 5px;
+  min-height: 40px;
+  text-align: left;
+}
+
+.view-btn {
+  background-color: var(--q-secondary);
+  border-radius: 5px;
+  border: none;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 17px;
+  overflow: hidden;
+  padding: 6px 18px;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.view-btn:hover {
+  background-color: var(--q-primary);
+}
+
+.top-content {
+  position: fixed;
+  width: 100%;
+  z-index: 15;
+}
+
+.charts {
+  max-height: 550px;
+}
+
+.tables {
+  padding-top: 550px;
+}
+
+/* Responsive columns */
+@media screen and (max-width: 600px) {
+  .top-content {
+    position: inherit;
+  }
+
+  .tables {
+    padding-top: 0;
+  }
+}

--- a/source/file_size_metrics/static/index.html
+++ b/source/file_size_metrics/static/index.html
@@ -1,172 +1,27 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="light">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <script>
+      (function (window, document) {
+        const params = new URLSearchParams(window.location.search);
+
+        if (params.has("theme") && params.get("theme") === "dark") {
+          document
+            .getElementsByTagName("html")[0]
+            .classList.replace("light", "dark");
+        }
+      })(window, document);
+    </script>
+
     <title>File Size Metrics | Unmanic</title>
     <link rel="shortcut icon" href="static/favicon.ico">
 
     <link rel="stylesheet" type="text/css"
           href="./static/vendor/datatables.net-dt/css/jquery.dataTables.min.css?{cache_buster}">
-
-    <style>
-        .hidden {
-            display: none;
-        }
-
-        table.dataTable {
-            background-color: #ffffff;
-        }
-
-        table.dataTable td {
-            word-break: break-word;
-        }
-
-        * {
-            box-sizing: border-box;
-        }
-
-        /* Float four columns side by side */
-        .column {
-            float: left;
-            width: 50%;
-            padding: 0 10px;
-        }
-
-        /* Remove extra left and right margins, due to padding */
-        .row {
-            margin: 0 -5px;
-        }
-
-        /* Clear floats after the columns */
-        .row:after {
-            content: "";
-            display: table;
-            clear: both;
-        }
-
-        /* Responsive columns */
-        @media screen and (max-width: 600px) {
-            .column {
-                width: 100%;
-                display: block;
-                margin-bottom: 20px;
-            }
-        }
-
-        /*Cards*/
-        .card {
-            box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-            /*padding: 16px;*/
-            text-align: center;
-            background-color: #ffffff;
-        }
-
-        .collapsible {
-            background-color: #777;
-            color: white;
-            cursor: pointer;
-            padding-left: 18px;
-            padding-right: 18px;
-            width: 100%;
-            border: none;
-            text-align: left;
-            outline: none;
-            font-size: 15px;
-            height: 35px;
-        }
-
-        button.collapsible::after {
-            content: "\2212";
-            color: white;
-            font-weight: bold;
-            float: right;
-            margin-left: 5px;
-
-        }
-
-        button.collapsible.active::after {
-            content: '\002B';
-        }
-
-        .active, .collapsible:hover {
-            background-color: #555;
-        }
-
-        .content {
-            padding: 0 18px;
-            display: none;
-            overflow: hidden;
-            background-color: #ffffff;
-        }
-
-        /*Back to top*/
-        .top-of-page-link svg {
-            -webkit-filter: drop-shadow(0 2px 5px rgba(0, 0, 0, .3));
-            filter: drop-shadow(0 2px 5px rgba(0, 0, 0, .3));
-        }
-
-        .top-of-page-link {
-            transition: .2s;
-            position: fixed;
-            bottom: 0.2rem;
-            right: 1rem;
-            z-index: 15;
-        }
-
-        /*Custom*/
-        .car-header {
-            display: block;
-            min-height: 40px;
-            height: 100px;
-            text-align: left;
-            margin-top: 5px;
-        }
-
-        .view-btn {
-            background-color: #009fdd !important;
-            border-radius: 5px;
-            font-size: 17px;
-            font-family: 'Source Sans Pro', sans-serif;
-            padding: 6px 18px;
-            color: #FFFFFF;
-            border: none;
-            display: inline-block;
-            vertical-align: middle;
-            overflow: hidden;
-            text-decoration: none;
-            text-align: center;
-            cursor: pointer;
-            white-space: nowrap;
-        }
-
-        .top-content {
-            position: fixed;
-            z-index: 15;
-            width: 100%;
-        }
-
-        .charts {
-            max-height: 550px;
-        }
-
-        .tables {
-            padding-top: 550px;
-        }
-
-        /* Responsive columns */
-        @media screen and (max-width: 600px) {
-            .top-content {
-                position: inherit;
-            }
-
-            .tables {
-                padding-top: 0;
-            }
-        }
-
-    </style>
-
+    <link rel="stylesheet" type="text/css" href="./static/css/style.css" />
 </head>
 <body id="top-of-page">
 


### PR DESCRIPTION
Initial dark mode support for the File Size Metrics plugin.

It doesn't respond to toggling the theme, because its an iframe and the theme is passed in as a query string parameter, so I don't believe that'll be possible without forcing it to reload.

For now this just moves the CSS out into its own file (because it's getting long) and then moves a lot of the colours to use `var(...)` syntax which is set in either a `light` or `dark` class that is added to the `html` tag. This is done with a little bit of JS as high up the document as possible, to try and reduce any colour flickering (the JS just checks for the query param and then replaces `light` with `dark` on the `html` tag).

| | Light | Dark |
| - | - | - |
| Current | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/23871015-dd4a-428a-bc53-dc5097db7a3a) | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/367e2e8f-50c4-486e-b6f2-1495e596fa77) |
| New |![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/7387346d-7548-46b3-9699-564940ee6135) | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/6c4116f3-8075-4f85-b553-2b8235f1e9a8) |

The SVGs don't respect the theme at the moment, but I am having a look into this to see what can be done.
