### PR TITLE
Update metric charts to support dark mode

### DIFF
--- a/source/file_size_metrics/changelog.md
+++ b/source/file_size_metrics/changelog.md
@@ -1,3 +1,6 @@
+**<span style="color:#56adda">0.0.11</span>**
+- File Size charts now support the dark theme
+
 **<span style="color:#56adda">0.0.10</span>**
 - Initial version of dark mode support
 

--- a/source/file_size_metrics/info.json
+++ b/source/file_size_metrics/info.json
@@ -11,5 +11,5 @@
     "on_postprocessor_task_results": 0
   },
   "tags": "data panel",
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/source/file_size_metrics/static/css/style.css
+++ b/source/file_size_metrics/static/css/style.css
@@ -6,7 +6,10 @@
   --q-primary: #002e5c;
   --q-secondary: #009fdd;
   --q-text: #000000;
+  --q-subtext: #838383;
   --q-warning: #f2c037;
+  --q-positive: #21ba45;
+  --q-negative: #c10015;
 }
 
 .dark {
@@ -17,7 +20,10 @@
   --q-primary: #009fdd;
   --q-secondary: #002e5c;
   --q-text: #ffffff;
+  --q-subtext: #bababa;
   --q-warning: #b5902a;
+  --q-positive: #21ba45;
+  --q-negative: #c10015;
 }
 
 .hidden {

--- a/source/file_size_metrics/static/js/filesizechart.js
+++ b/source/file_size_metrics/static/js/filesizechart.js
@@ -1,213 +1,250 @@
-const CompletedTasksFileSizeDiffChart = function () {
-
-    /**
-     * Format a byte integer into the smallest possible number appending a suffix
-     *
-     * REF:
-     *  https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
-     *
-     * @param bytes
-     * @param decimals
-     * @returns {string}
-     */
-    const formatBytes = function (bytes) {
-        if (bytes === 0) return '0 Bytes';
-        // Rather than using `let k = 1024;` (base 2) use `let k = 1000;` (base 10)
-        // This way the end result will better fit in with the high chart logic
-        // Using Base 2 will lead to the chart sections showing a rounded number and the bar showing something different
-        let k = 1000;
-        let dm = 2
-        let sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-        let i = Math.floor(Math.log(bytes) / Math.log(k));
-        return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
-    };
-
-    let positive = '#009fdd';
-    let negative = '#C10015';
-
-    let chart_title = '(Select a task from the table below)';
-    let source_file_size = 0;
-    let destination_file_size = 0;
-    let source_total_size = 0;
-    let destination_total_size = 0;
-
-    const individualChart = Highcharts.chart('file_size_chart', {
-        title: {
-            text: ''
-        },
-        subtitle: {
-            text: chart_title
-        },
-        colors: ['#555555', '#cccccc'],
-        xAxis: {
-            categories: ['Original', 'New']
-        },
-        series: []
-    });
-
-    const totalChart = Highcharts.chart('total_size_chart', {
-        title: {
-            text: ''
-        },
-        subtitle: {
-            text: 'Displaying the total file size changed on disk by Unmanic processing files'
-        },
-        colors: ['#555555', '#cccccc'],
-        xAxis: {
-            categories: ['Before', 'After']
-        },
-        series: []
-    });
-
-
-    const updateIndividualChart = function () {
-        // If the destination file size is greater than the source, then mark it negative, otherwise positive
-        let reduced = true;
-        let destination_bar_colour = positive;
-        let percent_changed = 100 - (destination_file_size / source_file_size * 100);
-        if (destination_file_size >= source_file_size) {
-            reduced = false;
-            destination_bar_colour = negative;
-            percent_changed = 100 - (source_file_size / destination_file_size * 100);
-        }
-        source_file_size = Number(source_file_size)
-        destination_file_size = Number(destination_file_size)
-
-        individualChart.update({
-            chart: {
-                type: 'bar',
-                width: null
-            },
-            colors: ['#555555', destination_bar_colour],
-            title: {
-                text: Highcharts.numberFormat(percent_changed, 2) + '% ' + ((reduced) ? 'decrease' : 'increase') + ' in file size'
-            },
-            subtitle: {
-                text: chart_title
-            },
-            tooltip: {
-                formatter: function () {
-                    return '<b>' + this.series.name + '</b><br/>' +
-                        'File Size: ' + formatBytes(Math.abs(this.point.y));
-                }
-            },
-        });
-        let newSeriesData = [
-            {
-                name: 'New',
-                data: [0, destination_file_size]
-            },
-            {
-                name: 'Original',
-                data: [source_file_size, 0]
-            },
-        ]
-        for (let i = individualChart.series.length - 1; i >= 0; i--) {
-            individualChart.series[i].remove();
-        }
-        for (let y = newSeriesData.length - 1; y >= 0; y--) {
-            individualChart.addSeries(newSeriesData[y]);
-        }
-    };
-
-
-    const updateTotalChart = function () {
-        // If the destination file size is greater than the source, then mark it negative, otherwise positive
-        let change_text = 'decrease';
-        let destination_bar_colour = positive;
-        let difference_in_total_file_sizes = (source_total_size - destination_total_size)
-        if (destination_total_size > source_total_size) {
-            change_text = 'increase';
-            destination_bar_colour = negative;
-            difference_in_total_file_sizes = (destination_total_size - source_total_size)
-        }
-        source_total_size = Number(source_total_size)
-        destination_total_size = Number(destination_total_size)
-
-        totalChart.update({
-            chart: {
-                type: 'bar',
-                width: null
-            },
-            title: {
-                text: formatBytes(difference_in_total_file_sizes) + ' total ' + change_text + ' in file size'
-            },
-            colors: ['#555555', destination_bar_colour],
-            tooltip: {
-                formatter: function () {
-                    return '<b>' + this.series.name + '</b><br/>' +
-                        'File Size: ' + formatBytes(Math.abs(this.point.y));
-                }
-            },
-        });
-        let newSeriesData = [
-            {
-                name: 'After',
-                data: [0, destination_total_size]
-            },
-            {
-                name: 'Before',
-                data: [source_total_size, 0]
-            },
-        ]
-        for (let i = totalChart.series.length - 1; i >= 0; i--) {
-            totalChart.series[i].remove();
-        }
-        for (let y = newSeriesData.length - 1; y >= 0; y--) {
-            totalChart.addSeries(newSeriesData[y]);
-        }
-    };
-
-    const fetchConversionDetails = function (taskId) {
-        jQuery.get('conversionDetails/?task_id=' + taskId, function (data) {
-            // Update/set the conversion details list
-            let source_abspath = '';
-            let destination_abspath = '';
-            for (let i = 0; i < data.length; i++) {
-                let item = data[i];
-                if (item.type === 'source') {
-                    source_file_size = Number(item.size);
-                    source_abspath = item.abspath;
-                } else if (item.type === 'destination') {
-                    chart_title = item.basename;
-                    destination_file_size = Number(item.size);
-                    destination_abspath = item.abspath;
-                }
-            }
-            updateIndividualChart();
-
-            let html = 'Original File Path: "' + source_abspath + '"'
-            html += '<br>'
-            html += 'New File Path: "' + destination_abspath + '"'
-            $('#selected_task_name').html(html)
-        });
-    };
-
-    const fetchTotalFileSizeDetails = function () {
-        jQuery.get('totalSizeChange', function (data) {
-            // Update/set the conversion details list
-            source_total_size = data.source;
-            destination_total_size = data.destination;
-            updateTotalChart();
-        });
-    };
-
-    const watch = function () {
-        let selectedTaskId = $('#selected_task_id');
-        selectedTaskId.on("change", function () {
-            if (this.value !== '') {
-                fetchConversionDetails(this.value);
-            }
-        }).triggerHandler('change');
+const CompletedTasksFileSizeDiffChart = (function () {
+  /**
+   * Format a byte integer into the smallest possible number appending a suffix
+   *
+   * REF:
+   *  https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+   *
+   * @param bytes
+   * @param decimals
+   * @returns {string}
+   */
+  const formatBytes = function (bytes) {
+    if (bytes === 0) {
+      return "0 Bytes";
     }
 
-    return {
-        //main function to initiate the module
-        init: function () {
-            watch();
-            fetchTotalFileSizeDetails();
+    // Rather than using `let k = 1024;` (base 2) use `let k = 1000;` (base 10)
+    // This way the end result will better fit in with the high chart logic
+    // Using Base 2 will lead to the chart sections showing a rounded number and
+    // the bar showing something different
+    let k = 1000;
+    let dm = 2;
+    let sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    let i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+  };
+
+  let positive = "#009fdd";
+  let negative = "#C10015";
+
+  let chart_title = "(Select a task from the table below)";
+  let source_file_size = 0;
+  let destination_file_size = 0;
+  let source_total_size = 0;
+  let destination_total_size = 0;
+
+  const individualChart = Highcharts.chart("file_size_chart", {
+    title: {
+      text: "",
+    },
+    subtitle: {
+      text: chart_title,
+    },
+    colors: ["#555555", "#cccccc"],
+    xAxis: {
+      categories: ["Original", "New"],
+    },
+    series: [],
+  });
+
+  const totalChart = Highcharts.chart("total_size_chart", {
+    title: {
+      text: "",
+    },
+    subtitle: {
+      text: "Displaying the total file size changed on disk by Unmanic processing files",
+    },
+    colors: ["#555555", "#cccccc"],
+    xAxis: {
+      categories: ["Before", "After"],
+    },
+    series: [],
+  });
+
+  const updateIndividualChart = function () {
+    // If the destination file size is greater than the source, then mark it negative, otherwise positive
+    let reduced = true;
+    let destination_bar_colour = positive;
+    let percent_changed =
+      100 - (destination_file_size / source_file_size) * 100;
+
+    if (destination_file_size >= source_file_size) {
+      reduced = false;
+      destination_bar_colour = negative;
+      percent_changed = 100 - (source_file_size / destination_file_size) * 100;
+    }
+
+    source_file_size = Number(source_file_size);
+    destination_file_size = Number(destination_file_size);
+
+    individualChart.update({
+      chart: {
+        type: "bar",
+        width: null,
+      },
+      colors: ["#555555", destination_bar_colour],
+      title: {
+        text:
+          Highcharts.numberFormat(percent_changed, 2) +
+          "% " +
+          (reduced ? "decrease" : "increase") +
+          " in file size",
+      },
+      subtitle: {
+        text: chart_title,
+      },
+      tooltip: {
+        formatter: function () {
+          return (
+            "<b>" +
+            this.series.name +
+            "</b><br/>" +
+            "File Size: " +
+            formatBytes(Math.abs(this.point.y))
+          );
+        },
+      },
+    });
+
+    let newSeriesData = [
+      {
+        name: "New",
+        data: [0, destination_file_size],
+      },
+      {
+        name: "Original",
+        data: [source_file_size, 0],
+      },
+    ];
+
+    for (let i = individualChart.series.length - 1; i >= 0; i--) {
+      individualChart.series[i].remove();
+    }
+
+    for (let y = newSeriesData.length - 1; y >= 0; y--) {
+      individualChart.addSeries(newSeriesData[y]);
+    }
+  };
+
+  const updateTotalChart = function () {
+    // If the destination file size is greater than the source, then mark it
+    // negative, otherwise positive
+    let change_text = "decrease";
+    let destination_bar_colour = positive;
+    let difference_in_total_file_sizes =
+      source_total_size - destination_total_size;
+
+    if (destination_total_size > source_total_size) {
+      change_text = "increase";
+      destination_bar_colour = negative;
+      difference_in_total_file_sizes =
+        destination_total_size - source_total_size;
+    }
+
+    source_total_size = Number(source_total_size);
+    destination_total_size = Number(destination_total_size);
+
+    totalChart.update({
+      chart: {
+        type: "bar",
+        width: null,
+      },
+      title: {
+        text:
+          formatBytes(difference_in_total_file_sizes) +
+          " total " +
+          change_text +
+          " in file size",
+      },
+      colors: ["#555555", destination_bar_colour],
+      tooltip: {
+        formatter: function () {
+          return (
+            "<b>" +
+            this.series.name +
+            "</b><br/>" +
+            "File Size: " +
+            formatBytes(Math.abs(this.point.y))
+          );
+        },
+      },
+    });
+
+    let newSeriesData = [
+      {
+        name: "After",
+        data: [0, destination_total_size],
+      },
+      {
+        name: "Before",
+        data: [source_total_size, 0],
+      },
+    ];
+
+    for (let i = totalChart.series.length - 1; i >= 0; i--) {
+      totalChart.series[i].remove();
+    }
+
+    for (let y = newSeriesData.length - 1; y >= 0; y--) {
+      totalChart.addSeries(newSeriesData[y]);
+    }
+  };
+
+  const fetchConversionDetails = function (taskId) {
+    jQuery.get("conversionDetails/?task_id=" + taskId, function (data) {
+      // Update/set the conversion details list
+      let source_abspath = "";
+      let destination_abspath = "";
+
+      for (let i = 0; i < data.length; i++) {
+        let item = data[i];
+
+        if (item.type === "source") {
+          source_file_size = Number(item.size);
+          source_abspath = item.abspath;
+        } else if (item.type === "destination") {
+          chart_title = item.basename;
+          destination_file_size = Number(item.size);
+          destination_abspath = item.abspath;
         }
-    };
+      }
 
-}();
+      updateIndividualChart();
 
+      let html = 'Original File Path: "' + source_abspath + '"';
+      html += "<br>";
+      html += 'New File Path: "' + destination_abspath + '"';
+      $("#selected_task_name").html(html);
+    });
+  };
+
+  const fetchTotalFileSizeDetails = function () {
+    jQuery.get("totalSizeChange", function (data) {
+      // Update/set the conversion details list
+      source_total_size = data.source;
+      destination_total_size = data.destination;
+      updateTotalChart();
+    });
+  };
+
+  const watch = function () {
+    let selectedTaskId = $("#selected_task_id");
+    selectedTaskId
+      .on("change", function () {
+        if (this.value !== "") {
+          fetchConversionDetails(this.value);
+        }
+      })
+      .triggerHandler("change");
+  };
+
+  return {
+    //main function to initiate the module
+    init: function () {
+      watch();
+      fetchTotalFileSizeDetails();
+    },
+  };
+})();

--- a/source/file_size_metrics/static/js/filesizechart.js
+++ b/source/file_size_metrics/static/js/filesizechart.js
@@ -14,20 +14,20 @@ const CompletedTasksFileSizeDiffChart = (function () {
       return "0 Bytes";
     }
 
-    // Rather than using `let k = 1024;` (base 2) use `let k = 1000;` (base 10)
+    // Rather than using `k = 1024;` (base 2) use `k = 1000;` (base 10)
     // This way the end result will better fit in with the high chart logic
     // Using Base 2 will lead to the chart sections showing a rounded number and
     // the bar showing something different
-    let k = 1000;
-    let dm = 2;
-    let sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-    let i = Math.floor(Math.log(bytes) / Math.log(k));
+    const k = 1000;
+    const dm = 2;
+    const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
 
     return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
   };
 
-  let positive = "#009fdd";
-  let negative = "#C10015";
+  const positive = "#009fdd";
+  const negative = "#C10015";
 
   let chart_title = "(Select a task from the table below)";
   let source_file_size = 0;
@@ -64,7 +64,8 @@ const CompletedTasksFileSizeDiffChart = (function () {
   });
 
   const updateIndividualChart = function () {
-    // If the destination file size is greater than the source, then mark it negative, otherwise positive
+    // If the destination file size is greater than the source, then mark it
+    // negative, otherwise positive
     let reduced = true;
     let destination_bar_colour = positive;
     let percent_changed =
@@ -97,18 +98,14 @@ const CompletedTasksFileSizeDiffChart = (function () {
       },
       tooltip: {
         formatter: function () {
-          return (
-            "<b>" +
-            this.series.name +
-            "</b><br/>" +
-            "File Size: " +
-            formatBytes(Math.abs(this.point.y))
-          );
+          return `<strong>${this.series.name}</strong>
+            <br>
+            File Size: ${formatBytes(Math.abs(this.point.y))}`;
         },
       },
     });
 
-    let newSeriesData = [
+    const newSeriesData = [
       {
         name: "New",
         data: [0, destination_file_size],
@@ -152,27 +149,20 @@ const CompletedTasksFileSizeDiffChart = (function () {
         width: null,
       },
       title: {
-        text:
-          formatBytes(difference_in_total_file_sizes) +
-          " total " +
-          change_text +
-          " in file size",
+        text: `${formatBytes(difference_in_total_file_sizes)}
+          total ${change_text} in file size`,
       },
       colors: ["#555555", destination_bar_colour],
       tooltip: {
         formatter: function () {
-          return (
-            "<b>" +
-            this.series.name +
-            "</b><br/>" +
-            "File Size: " +
-            formatBytes(Math.abs(this.point.y))
-          );
+          return `<strong>${this.series.name}</strong>
+            <br>
+            File Size: ${formatBytes(Math.abs(this.point.y))}`;
         },
       },
     });
 
-    let newSeriesData = [
+    const newSeriesData = [
       {
         name: "After",
         data: [0, destination_total_size],
@@ -193,13 +183,13 @@ const CompletedTasksFileSizeDiffChart = (function () {
   };
 
   const fetchConversionDetails = function (taskId) {
-    jQuery.get("conversionDetails/?task_id=" + taskId, function (data) {
+    jQuery.get(`conversionDetails/?task_id=${taskId}`, function (data) {
       // Update/set the conversion details list
       let source_abspath = "";
       let destination_abspath = "";
 
       for (let i = 0; i < data.length; i++) {
-        let item = data[i];
+        const item = data[i];
 
         if (item.type === "source") {
           source_file_size = Number(item.size);
@@ -213,9 +203,10 @@ const CompletedTasksFileSizeDiffChart = (function () {
 
       updateIndividualChart();
 
-      let html = 'Original File Path: "' + source_abspath + '"';
-      html += "<br>";
-      html += 'New File Path: "' + destination_abspath + '"';
+      const html = `Original File Path: "${source_abspath}"
+        <br>
+        New File Path: "${destination_abspath}"`;
+
       $("#selected_task_name").html(html);
     });
   };
@@ -230,7 +221,8 @@ const CompletedTasksFileSizeDiffChart = (function () {
   };
 
   const watch = function () {
-    let selectedTaskId = $("#selected_task_id");
+    const selectedTaskId = $("#selected_task_id");
+
     selectedTaskId
       .on("change", function () {
         if (this.value !== "") {

--- a/source/file_size_metrics/static/js/filesizechart.js
+++ b/source/file_size_metrics/static/js/filesizechart.js
@@ -26,8 +26,12 @@ const CompletedTasksFileSizeDiffChart = (function () {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
   };
 
-  const positive = "#009fdd";
-  const negative = "#C10015";
+  const default_bar_colour = "#555";
+  const positive_bar_colour = "var(--q-positive)";
+  const negative_bar_colour = "var(--q-negative)";
+  const text_colour = "var(--q-text)";
+  const subtext_colour = "var(--q-subtext)";
+  const chart_background = "var(--q-card)";
 
   let chart_title = "(Select a task from the table below)";
   let source_file_size = 0;
@@ -36,29 +40,95 @@ const CompletedTasksFileSizeDiffChart = (function () {
   let destination_total_size = 0;
 
   const individualChart = Highcharts.chart("file_size_chart", {
+    chart: {
+      backgroundColor: chart_background,
+    },
     title: {
       text: "",
+      style: {
+        color: text_colour,
+      },
     },
     subtitle: {
       text: chart_title,
+      style: {
+        color: subtext_colour,
+      },
     },
-    colors: ["#555555", "#cccccc"],
+    colors: [default_bar_colour, positive_bar_colour],
     xAxis: {
       categories: ["Original", "New"],
+      labels: {
+        style: {
+          color: text_colour,
+        },
+      },
+      lineColor: text_colour,
+    },
+    yAxis: {
+      labels: {
+        style: {
+          color: text_colour,
+        },
+      },
+      title: {
+        text: "Sizes",
+        style: {
+          color: subtext_colour,
+        },
+      },
+    },
+    legend: {
+      itemStyle: {
+        color: text_colour,
+      },
     },
     series: [],
   });
 
   const totalChart = Highcharts.chart("total_size_chart", {
+    chart: {
+      backgroundColor: chart_background,
+    },
     title: {
       text: "",
+      style: {
+        color: text_colour,
+      },
     },
     subtitle: {
       text: "Displaying the total file size changed on disk by Unmanic processing files",
+      style: {
+        color: subtext_colour,
+      },
     },
-    colors: ["#555555", "#cccccc"],
+    colors: [default_bar_colour, positive_bar_colour],
     xAxis: {
       categories: ["Before", "After"],
+      labels: {
+        style: {
+          color: text_colour,
+        },
+      },
+      lineColor: text_colour,
+    },
+    yAxis: {
+      labels: {
+        style: {
+          color: text_colour,
+        },
+      },
+      title: {
+        text: "Sizes",
+        style: {
+          color: subtext_colour,
+        },
+      },
+    },
+    legend: {
+      itemStyle: {
+        color: text_colour,
+      },
     },
     series: [],
   });
@@ -67,25 +137,24 @@ const CompletedTasksFileSizeDiffChart = (function () {
     // If the destination file size is greater than the source, then mark it
     // negative, otherwise positive
     let reduced = true;
-    let destination_bar_colour = positive;
+    let destination_bar_colour = positive_bar_colour;
     let percent_changed =
       100 - (destination_file_size / source_file_size) * 100;
-
     if (destination_file_size >= source_file_size) {
       reduced = false;
-      destination_bar_colour = negative;
+      destination_bar_colour = negative_bar_colour;
       percent_changed = 100 - (source_file_size / destination_file_size) * 100;
     }
-
     source_file_size = Number(source_file_size);
     destination_file_size = Number(destination_file_size);
 
     individualChart.update({
       chart: {
+        backgroundColor: chart_background,
         type: "bar",
         width: null,
       },
-      colors: ["#555555", destination_bar_colour],
+      colors: [default_bar_colour, destination_bar_colour],
       title: {
         text:
           Highcharts.numberFormat(percent_changed, 2) +
@@ -109,33 +178,36 @@ const CompletedTasksFileSizeDiffChart = (function () {
       {
         name: "New",
         data: [0, destination_file_size],
+        borderColor: chart_background,
       },
       {
         name: "Original",
         data: [source_file_size, 0],
+        borderColor: chart_background,
       },
     ];
 
     for (let i = individualChart.series.length - 1; i >= 0; i--) {
-      individualChart.series[i].remove();
+      individualChart.series[i].remove(false);
     }
 
     for (let y = newSeriesData.length - 1; y >= 0; y--) {
-      individualChart.addSeries(newSeriesData[y]);
+      individualChart.addSeries(newSeriesData[y], false);
     }
+
+    individualChart.redraw();
   };
 
   const updateTotalChart = function () {
     // If the destination file size is greater than the source, then mark it
     // negative, otherwise positive
     let change_text = "decrease";
-    let destination_bar_colour = positive;
+    let destination_bar_colour = positive_bar_colour;
     let difference_in_total_file_sizes =
       source_total_size - destination_total_size;
-
     if (destination_total_size > source_total_size) {
       change_text = "increase";
-      destination_bar_colour = negative;
+      destination_bar_colour = negative_bar_colour;
       difference_in_total_file_sizes =
         destination_total_size - source_total_size;
     }
@@ -145,6 +217,7 @@ const CompletedTasksFileSizeDiffChart = (function () {
 
     totalChart.update({
       chart: {
+        backgroundColor: chart_background,
         type: "bar",
         width: null,
       },
@@ -152,7 +225,7 @@ const CompletedTasksFileSizeDiffChart = (function () {
         text: `${formatBytes(difference_in_total_file_sizes)}
           total ${change_text} in file size`,
       },
-      colors: ["#555555", destination_bar_colour],
+      colors: [default_bar_colour, destination_bar_colour],
       tooltip: {
         formatter: function () {
           return `<strong>${this.series.name}</strong>
@@ -166,20 +239,24 @@ const CompletedTasksFileSizeDiffChart = (function () {
       {
         name: "After",
         data: [0, destination_total_size],
+        borderColor: chart_background,
       },
       {
         name: "Before",
         data: [source_total_size, 0],
+        borderColor: chart_background,
       },
     ];
 
     for (let i = totalChart.series.length - 1; i >= 0; i--) {
-      totalChart.series[i].remove();
+      totalChart.series[i].remove(false);
     }
 
     for (let y = newSeriesData.length - 1; y >= 0; y--) {
-      totalChart.addSeries(newSeriesData[y]);
+      totalChart.addSeries(newSeriesData[y], false);
     }
+
+    totalChart.redraw();
   };
 
   const fetchConversionDetails = function (taskId) {


### PR DESCRIPTION
Updated the charting library to use the CSS variables that are defined on the page.


| | Light | Dark |
| - | - | - |
| Current | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/046f2775-9bfa-4a6a-afa7-0dbb679c16c5) | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/04205597-d3ad-4fbc-9e58-d29a53e0d48a) |
| New | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/8cb3a870-5aec-479c-9185-e0e7fc22cddb) | ![image](https://github.com/Unmanic/unmanic-plugins/assets/115825/4f595717-b6ad-4bc9-bd40-78972dc4053b) |

As part of the updates I've changed the colours to use the `--q-positive` and `--q-negative` that are defined on the main pages. This means the blue bars are now green if there has been a reduction in the file size.