### PR TITLE
update [remove_streams_by_codec] v0.0.2

### DIFF
--- a/source/remove_streams_by_codec/info.json
+++ b/source/remove_streams_by_codec/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 1
     },
     "tags": "ffmpeg,library file test",
-    "version": "0.0.1"
+    "version": "0.0.2"
 }

--- a/source/remove_streams_by_codec/plugin.py
+++ b/source/remove_streams_by_codec/plugin.py
@@ -54,7 +54,10 @@ class PluginStreamMapper(StreamMapper):
 
     def test_stream_needs_processing(self, stream_info: dict):
         """Check if this stream matches configured codecs."""
-        return stream_info.get('codec_name').lower() in self.codecs
+        codec_name = stream_info.get('codec_name')
+        if (codec_name is None):
+            return False
+        return codec_name.lower() in self.codecs
 
     def custom_stream_mapping(self, stream_info: dict, stream_id: int):
         """Do not map the streams matched above"""


### PR DESCRIPTION
Updates the remove_streams_by_codec adding a None check in test_stream_needs_processing.
Fixes an error which occurred if a stream has no codec name.