### PR TITLE
switch to file_out=None for mkvpropedit

### DIFF
--- a/source/mkvpropedit/changelog.md
+++ b/source/mkvpropedit/changelog.md
@@ -1,3 +1,8 @@
+
+**<span style="color:#56adda">0.0.3</span>**
+
+- Set file_out to None instead of creating a hardlinked copy as the file_out
+
 **<span style="color:#56adda">0.0.2</span>**
 
 - Fix invalid plugin tags

--- a/source/mkvpropedit/info.json
+++ b/source/mkvpropedit/info.json
@@ -9,5 +9,5 @@
     "on_worker_process": 99
   },
   "tags": "command, mkv, tweaks",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/source/mkvpropedit/plugin.py
+++ b/source/mkvpropedit/plugin.py
@@ -144,9 +144,6 @@ def on_worker_process(data):
         tree.write(tags_filename)
 
     def process_file():
-        # Copy the input file to the output file
-        os.link(data.get('file_in'), data.get('file_out'))
-
         # Start off with calling mkvpropedit
         command = ['mkvpropedit']
 
@@ -162,10 +159,10 @@ def on_worker_process(data):
             command.extend(other_args.split())
 
         # Pass in working file name
-        command.append(data.get('file_out'))
+        command.append(data.get('file_in'))
 
         # Execute the command
-        if command == ['mkvpropedit', data.get('file_out')]:
+        if command == ['mkvpropedit', data.get('file_in')]:
             logger.error("No arguments provided for mkvpropedit, skipping...")
             return
 
@@ -179,5 +176,8 @@ def on_worker_process(data):
         process_file()
 
     data['command_progress_parser'] = parse_progress
+
+    # Set the output file to None since mkvpropedit does not create a new file
+    data['file_out'] = None
 
     return data


### PR DESCRIPTION
> [!WARNING]
> This should not be merged until after the issue preventing file_out being None is fixed

This will switch from creating a hardlinked copy to the file out to setting the file_out to `None`