### PR TITLE
[ignore_files_based_on_metadata] 0.0.5

### DIFF
--- a/source/ignore_files_based_on_metadata/changelog.md
+++ b/source/ignore_files_based_on_metadata/changelog.md
@@ -1,6 +1,11 @@
 
+**<span style="color:#56adda">0.0.5</span>**
+- add subtitle format section
+- add audio mime type to the plugin
+- make the stream search for disallowed values apply to all stream types and not just video
+
 **<span style="color:#56adda">0.0.4</span>**
-- generalized use of stream tags for audio and video streams too
+- generalize tag inclusion to video and audio streams too
 
 **<span style="color:#56adda">0.0.3</span>**
 - add test to check attachment streams tags

--- a/source/ignore_files_based_on_metadata/info.json
+++ b/source/ignore_files_based_on_metadata/info.json
@@ -14,5 +14,5 @@
         "on_library_management_file_test": 1
     },
     "tags": "library file test",
-    "version": "0.0.4"
+    "version": "0.0.5"
 }

--- a/source/ignore_files_based_on_metadata/plugin.py
+++ b/source/ignore_files_based_on_metadata/plugin.py
@@ -64,7 +64,7 @@ def file_has_disallowed_metadata(path, disallowed_metadata, metadata_value):
     """
 
     # initialize Probe
-    probe_data=Probe(logger, allowed_mimetypes=['video'])
+    probe_data=Probe(logger, allowed_mimetypes=['video', 'audio'])
 
     # Get stream data from probe
     if probe_data.file(path):
@@ -80,7 +80,7 @@ def file_has_disallowed_metadata(path, disallowed_metadata, metadata_value):
         return True
 
     # Check if stream or format components contain disallowed metadata
-    streams = [probe_streams[i] for i in range(0, len(probe_streams)) if "codec_type" in probe_streams[i] and probe_streams[i]["codec_type"] == "video"]
+    streams = [probe_streams[i] for i in range(0, len(probe_streams)) if "codec_type" in probe_streams[i] and probe_streams[i]["codec_type"] in ["video", 'audio', 'attachment', 'subtitle']]
     file_has_disallowed_metadata = [streams[i] for i in range(0, len(streams)) if disallowed_metadata in streams[i] and metadata_value in streams[i][disallowed_metadata]]
     probe_format_d = {k:v for  (k, v) in probe_format.items() if type(v) is dict}
     probe_format_kv = {k:v for  (k, v) in probe_format.items() if type(v) is not dict}
@@ -96,6 +96,13 @@ def file_has_disallowed_metadata(path, disallowed_metadata, metadata_value):
     except KeyError:
         file_has_disallowed_metadata_ast = ""
 
+    subtitle_streams = [probe_streams[i] for i in range(0, len(probe_streams)) if "codec_type" in probe_streams[i] and probe_streams[i]["codec_type"] == "subtitle"]
+    try:
+        probe_ss_tags_kv = {k:v for i in range(0, len(attachment_streams)) for (k, v) in attachment_streams[i]["tags"].items() if type(v) is not dict}
+        file_has_disallowed_metadata_sst = [(k, v) for (k, v) in probe_ss_tags_kv.items() if (disallowed_metadata in k.lower() and metadata_value in v)]
+    except KeyError:
+        file_has_disallowed_metadata_sst = ""
+
     video_streams = [probe_streams[i] for i in range(0, len(probe_streams)) if "codec_type" in probe_streams[i] and probe_streams[i]["codec_type"] == "video"]
     try:
         probe_vs_tags_kv = {k:v for i in range(0, len(video_streams)) for (k, v) in video_streams[i]["tags"].items() if type(v) is not dict}
@@ -110,7 +117,7 @@ def file_has_disallowed_metadata(path, disallowed_metadata, metadata_value):
     except KeyError:
         file_has_disallowed_metadata_aust = ""
 
-    if file_has_disallowed_metadata or file_has_disallowed_metadata_fmt or file_has_disallowed_metadata_ast or file_has_disallowed_metadata_vst or file_has_disallowed_metadata_aust:
+    if file_has_disallowed_metadata or file_has_disallowed_metadata_fmt or file_has_disallowed_metadata_ast or file_has_disallowed_metadata_sst or file_has_disallowed_metadata_vst or file_has_disallowed_metadata_aust:
         logger.debug("File '{}' contains disallowed metadata '{}': '{}'.".format(path, disallowed_metadata, metadata_value))
         return True
 


### PR DESCRIPTION
- Added audio streams to allowable mime types
- added other stream types besides video streams to be search for matching ffprobe data fields
- added subtitle stream types when searching for matches in format fields