### PR TITLE
[extract_srt_subtitles_to_files] 0.0.11

### DIFF
--- a/source/extract_srt_subtitles_to_files/changelog.md
+++ b/source/extract_srt_subtitles_to_files/changelog.md
@@ -1,3 +1,7 @@
+
+**<span style="color:#56adda">0.0.11</span>**
+- remove note in description.md since plugin has a file test section since 0.0.8
+	
 **<span style="color:#56adda">0.0.10</span>**
 - Added user of .unmanic file to track processed files
 

--- a/source/extract_srt_subtitles_to_files/description.md
+++ b/source/extract_srt_subtitles_to_files/description.md
@@ -8,8 +8,3 @@ This plugin is not compatible with linking as the remote link will not have acce
 To include other formats, such as ASS, consider first converting the subtitle streams to SRT using the Plugin(s) 
 
 Install the **"Convert any ASS subtitle streams in videos to SRT"** plugin and configure the plugin flow to set it before this one
-
-:::note
-This Plugin does not contain a file tester to detect files that contain SRT subtitle streams.
-Ensure it is pared with another Plugin.
-:::

--- a/source/extract_srt_subtitles_to_files/info.json
+++ b/source/extract_srt_subtitles_to_files/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 2
     },
     "tags": "subtitle,ffmpeg",
-    "version": "0.0.10"
+    "version": "0.0.11"
 }


### PR DESCRIPTION
deleted the note in description.md about plugin not having a file test section and to pair it with another plugin that did.  Starting in v0.0.8 this plugin has a file test section so the note was obsolete.