### PR TITLE
Add support for STV-AV1 encoder

### DIFF
--- a/source/video_transcoder/changelog.md
+++ b/source/video_transcoder/changelog.md
@@ -1,3 +1,5 @@
+**<span style="color:#56adda">0.1.7</span>**
+ - Add support for the STV-AV1 encoder
 
 **<span style="color:#56adda">0.1.6</span>**
 - Fix bug causing files to be perpetually added to the task queue if mode is set to advanced, but the smart filters were previously applied

--- a/source/video_transcoder/info.json
+++ b/source/video_transcoder/info.json
@@ -12,5 +12,5 @@
         "on_worker_process": 1
     },
     "tags": "video,ffmpeg",
-    "version": "0.1.6"
+    "version": "0.1.7"
 }

--- a/source/video_transcoder/lib/encoders/libsvtav1.py
+++ b/source/video_transcoder/lib/encoders/libsvtav1.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    plugins.libx.py
+
+    Written by:               Josh.5 <jsunnex@gmail.com>
+    Date:                     12 Jun 2022, (9:48 AM)
+
+    Copyright:
+        Copyright (C) 2021 Josh Sunnex
+
+        This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+        Public License as published by the Free Software Foundation, version 3.
+
+        This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+        implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+        for more details.
+
+        You should have received a copy of the GNU General Public License along with this program.
+        If not, see <https://www.gnu.org/licenses/>.
+
+"""
+
+
+class LibsvtAv1Encoder:
+
+    def __init__(self, settings):
+        self.settings = settings
+
+    def provides(self):
+        return {
+            "libsvtav1": {
+                "codec": "av1",
+                "label": "CPU - libsvtav1",
+            }
+        }
+
+    def options(self):
+        return {
+            "preset":                     "4",
+            "encoder_ratecontrol_method": "CRF",
+            "constant_quality_scale":     "23",
+            "video_pix_fmt":              "auto",
+            "tune_stvav1":                1,
+            "overlays":                   0,
+            "variance_boost":             0,
+            "enable_qm":                  False,
+            "qm_min":                     "8",
+            "encoder_additional_params":  "no_additional_params",
+            "additional_params":           "",
+        }
+
+    def generate_default_args(self):
+        """
+        Generate a list of args for using a libx decoder
+
+        :return:
+        """
+        # No default args required
+        generic_kwargs = {}
+        advanced_kwargs = {}
+        return generic_kwargs, advanced_kwargs
+
+    def generate_filtergraphs(self):
+        """
+        Generate the required filter for this encoder
+        No filters are required for libx encoders
+
+        :return:
+        """
+        return []
+
+    def encoder_details(self, encoder):
+        provides = self.provides()
+        return provides.get(encoder, {})
+
+    def args(self, stream_id):
+        stream_encoding = []
+
+        # Use defaults for basic mode
+        if self.settings.get_setting('mode') in ['basic']:
+            defaults = self.options()
+            stream_encoding += [
+                '-preset', str(defaults.get('preset')),
+            ]
+            # TODO: Calculate best crf based on source bitrate
+            default_crf = defaults.get('constant_quality_scale')
+            if self.settings.get_setting('video_encoder') in ['libsvtav1']:
+                default_crf = 23
+            stream_encoding += ['-crf', str(default_crf)]
+            return stream_encoding
+        
+        stav1_params = ["enable-stat-report=1"]
+        stav1_params += ['tune=' + str(self.settings.get_setting('tune_stvav1'))]
+        
+        if self.settings.get_setting('overlays'):
+            # Enable overlays
+            stav1_params += ['enable-overlays=1']
+            
+        if self.settings.get_setting('variance_boost'):
+            # Enable variance boost
+            stav1_params += ['enable-variance-boost=1']
+            
+        if self.settings.get_setting('enable_qm'):
+            # Enable quantization matrix
+            stav1_params += ['enable-qm=1']
+            stav1_params += ['qm-min=' + str(self.settings.get_setting('qm_min'))]
+
+        if self.settings.get_setting('encoder_additional_params') in ['additional_params'] and len(self.settings.get_setting('encoder_svtav1_additional_params')):
+            # Add additional parameters for SVT-AV1
+            stav1_params += self.settings.get_setting('encoder_svtav1_additional_params')
+        
+        stream_encoding += ['-svtav1-params', ":".join(stav1_params)]
+        
+        # Add the preset
+        if self.settings.get_setting('preset'):
+            stream_encoding += ['-preset', str(self.settings.get_setting('preset'))]
+
+        if self.settings.get_setting('encoder_ratecontrol_method') in ['CRF']:
+            # Set values for constant quantizer scale
+            stream_encoding += [
+                '-crf', str(self.settings.get_setting('constant_quality_scale')),
+            ]
+
+        if self.settings.get_setting('video_pix_fmt') not in ['auto']:
+            # Set the pixel format
+            stream_encoding += ['-pix_fmt', str(self.settings.get_setting('video_pix_fmt'))]
+
+        return stream_encoding
+
+    def __set_default_option(self, select_options, key, default_option=None):
+        """
+        Sets the default option if the currently set option is not available
+
+        :param select_options:
+        :param key:
+        :return:
+        """
+        available_options = []
+        for option in select_options:
+            available_options.append(option.get('value'))
+            if not default_option:
+                default_option = option.get('value')
+        if self.settings.get_setting(key) not in available_options:
+            self.settings.set_setting(key, default_option)
+
+    def get_preset_form_settings(self):
+        values = {
+            "label":          "Encoder quality preset",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": "12",
+                    "label": "Very fast (12) - Fastest setting, biggest quality drop",
+                },
+                {
+                    "value": "10",
+                    "label": "Faster (10) - Close to medium/fast quality, faster performance",
+                },
+                {
+                    "value": "8",
+                    "label": "Fast (8)",
+                },
+                {
+                    "value": "6",
+                    "label": "Medium (6)",
+                },
+                {
+                    "value": "4",
+                    "label": "Slow (4) - Balanced performance and quality",
+                },
+                {
+                    "value": "2",
+                    "label": "Slower (2) - Close to 'very slow' quality, faster performance",
+                },
+                {
+                    "value": "1",
+                    "label": "Very Slow (1) - Best quality",
+                },
+            ],
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+
+    def get_encoder_ratecontrol_method_form_settings(self):
+        values = {
+            "label":          "Encoder ratecontrol method",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": "CRF",
+                    "label": "CRF - Constant Rate Factor",
+                },
+            ]
+        }
+        self.__set_default_option(values['select_options'], 'encoder_ratecontrol_method', default_option='CRF')
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+
+    def get_constant_quality_scale_form_settings(self):
+        # Lower is better
+        values = {
+            "label":          "Constant rate factor",
+            "description":    "",
+            "sub_setting":    True,
+            "input_type":     "slider",
+            "slider_options": {
+                "min": 1,
+                "max": 51,
+            },
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        if self.settings.get_setting('encoder_ratecontrol_method') not in ['CRF']:
+            values["display"] = "hidden"
+        if self.settings.get_setting('video_encoder') in ['libsvtav1']:
+            values["description"] = "Default value for libsvtav1 = 23"
+        return values
+    
+    def get_video_pix_fmt_form_settings(self):
+        values = {
+            "label":          "Pixel Format",
+            "description":    "Select the pixel format",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": "auto",
+                    "label": "Let ffmpeg decide (default)"
+                },
+                {
+                    "value": "yuv420p",
+                    "label": "yuv420p (8-bit, 4:2:0)"
+                },
+                {
+                    "value": "yuv420p10le",
+                    "label": "yuv420p10le (10-bit, 4:2:0)"
+                },
+            ],
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+    
+    def get_tune_stvav1_form_settings(self):
+        values = {
+            "label":          "SVT-AV1: Tune",
+            "description":    "VQ (Visual Quality), PSNR (Objective Quality), SSIM (Objective Quality).",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": 0,
+                    "label": "VQ (Recommended for animes, cartoons, and other animated content)",
+                },
+                {
+                    "value": 1,
+                    "label": "PSNR (default)",
+                },
+                {
+                    "value": 2,
+                    "label": "SSIM (Recommended for movies, TV shows, and other live-action content)",
+                },
+            ]
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+    
+    def get_overlays_form_settings(self):
+        values = {
+            "label":          "SVT-AV1: Enable Overlays",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": 0,
+                    "label": "No (Default)",
+                },
+                {   "value": 1,
+                    "label": "Yes"
+                },
+            ]
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+
+    def get_variance_boost_form_settings(self):
+        values = {
+            "label":          "SVT-AV1: Enable Variance Boost (enable-variance-boost)",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": 0,
+                    "label": "No (Default)"
+                },
+                {
+                    "value": 1,
+                    "label": "Yes"
+                },
+            ]
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+    
+    def get_enable_qm_form_settings(self):
+        values = {
+            "label":          "SVT-AV1: Enable Quantization Matrix (enable-qm)",
+            "description":    "",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": False,
+                    "label": "No (Default)"
+                },
+                {
+                    "value": True,
+                    "label": "Yes"
+                },
+            ]
+        }
+        self.__set_default_option(values['select_options'], 'enable_qm', default_option=False)
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+
+    def get_qm_min_form_settings(self):
+        values = {
+            "label":          "SVT-AV1: Quantization Matrix Min (qm-min)",
+            "description":    "Specifies qm-min level (Default: 8).",
+            "sub_setting":    True,
+            "input_type":     "slider",
+            "slider_options": {
+                "min": 0,
+                "max": 14,
+            },
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        if (not self.settings.get_setting('enable_qm')):
+            values["display"] = "hidden"
+            
+        return values
+    
+    def get_encoder_additional_params_form_settings(self):
+        values = {
+            "label":          "SVT-AV1: Additional Parameters",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": "additional_params",
+                    "label": "SVT-AV1: Additional Parameters",
+                },
+                {
+                    "value": "no_additional_params",
+                    "label": "No Additional Parameters",
+                },
+            ]
+        }
+        self.__set_default_option(values['select_options'], 'encoder_additional_params', default_option='no_additional_params')
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        return values
+    
+    def get_additional_params_form_settings(self):
+        values = {
+            "label": "SVT-AV1: Additional Parameters field",
+            "description": "Additional SVT-AV1 parameters as a colon-separated string (e.g., enable-cdef=1:enable-restoration=1).",
+            "sub_setting": True,
+            "input_type":  "textarea",
+        }
+        if self.settings.get_setting('mode') not in ['standard']:
+            values["display"] = "hidden"
+        if self.settings.get_setting('encoder_additional_params') not in ['additional_params']:
+            values["display"] = "hidden"
+        
+        return values

--- a/source/video_transcoder/lib/plugin_stream_mapper.py
+++ b/source/video_transcoder/lib/plugin_stream_mapper.py
@@ -28,6 +28,7 @@ from video_transcoder.lib.encoders.libx import LibxEncoder
 from video_transcoder.lib.encoders.qsv import QsvEncoder
 from video_transcoder.lib.encoders.vaapi import VaapiEncoder
 from video_transcoder.lib.encoders.nvenc import NvencEncoder
+from video_transcoder.lib.encoders.libsvtav1 import LibsvtAv1Encoder
 from video_transcoder.lib.ffmpeg import StreamMapper
 
 # Configure plugin logger
@@ -151,6 +152,7 @@ class PluginStreamMapper(StreamMapper):
         qsv_encoder = QsvEncoder(self.settings)
         vaapi_encoder = VaapiEncoder(self.settings)
         nvenc_encoder = NvencEncoder(self.settings)
+        stva1_encoder = LibsvtAv1Encoder(self.settings)
 
         # Apply smart filters first
         required_hw_smart_filters = []
@@ -320,6 +322,7 @@ class PluginStreamMapper(StreamMapper):
                 qsv_encoder = QsvEncoder(self.settings)
                 vaapi_encoder = VaapiEncoder(self.settings)
                 nvenc_encoder = NvencEncoder(self.settings)
+                stva1_encoder = LibsvtAv1Encoder(self.settings)
 
                 # Add encoder args
                 if self.settings.get_setting('video_encoder') in libx_encoder.provides():
@@ -332,6 +335,8 @@ class PluginStreamMapper(StreamMapper):
                     generic_kwargs, stream_encoding_args = nvenc_encoder.args(stream_info, stream_id)
                     self.set_ffmpeg_generic_options(**generic_kwargs)
                     stream_encoding += stream_encoding_args
+                elif self.settings.get_setting('video_encoder') in stva1_encoder.provides():
+                    stream_encoding += stva1_encoder.args(stream_id)
         elif codec_type in ['data']:
             if not self.settings.get_setting('apply_smart_filters'):
                 # If smart filters are not enabled, return 'False' to let the default mapping just copy the data stream

--- a/source/video_transcoder/plugin.py
+++ b/source/video_transcoder/plugin.py
@@ -41,6 +41,7 @@ from video_transcoder.lib.encoders.libx import LibxEncoder
 from video_transcoder.lib.encoders.qsv import QsvEncoder
 from video_transcoder.lib.encoders.vaapi import VaapiEncoder
 from video_transcoder.lib.encoders.nvenc import NvencEncoder
+from video_transcoder.lib.encoders.libsvtav1 import LibsvtAv1Encoder
 
 from unmanic.libs.unplugins.settings import PluginSettings
 from unmanic.libs.directoryinfo import UnmanicDirectoryInfo
@@ -95,6 +96,7 @@ class Settings(PluginSettings):
             QsvEncoder,
             VaapiEncoder,
             NvencEncoder,
+            LibsvtAv1Encoder,
         ]
         for encoder_class in encoder_libs:
             encoder_lib = encoder_class(self)
@@ -115,11 +117,13 @@ class Settings(PluginSettings):
         qsv_options = QsvEncoder(self.settings).options()
         vaapi_options = VaapiEncoder(self.settings).options()
         nvenc_options = NvencEncoder(self.settings).options()
+        libsvtav1_options = LibsvtAv1Encoder(self.settings).options()
         return {
             **libx_options,
             **qsv_options,
             **vaapi_options,
             **nvenc_options,
+            **libsvtav1_options,
         }
 
     def __build_settings_object(self):


### PR DESCRIPTION
Hello,

This pull request introduces support for the SVT-AV1 (Scalable Video Technology for AV1) encoder within the Unmanic plugins. SVT-AV1 is an open-source, CPU-based AV1 encoder developed by Intel and Netflix, offering a balance of encoding speed and quality for AV1 content. By adding SVT-AV1 support, users can now select libsvtav1 as their AV1 encoder in relevant plugin configurations.

Please let me know if any additional examples or parameter explanations are required. If you’d rather pull only the SVT-AV1 additions and apply them in your own commit instead of merging this PR directly, I have no problem with that approach.

Best regards