### PR TITLE
Fix whitespaces breaking limit by file extension

### DIFF
--- a/source/limit_library_search_by_file_extension/changelog.md
+++ b/source/limit_library_search_by_file_extension/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.5</span>**
+- Fix issue where whitespaces after commas between extensions caused only the first extension to be selected.
+
 **<span style="color:#56adda">0.0.4</span>**
 - Fix issue where the plugin was never ignoring files without an extension such as the '.unmanic' files
 

--- a/source/limit_library_search_by_file_extension/info.json
+++ b/source/limit_library_search_by_file_extension/info.json
@@ -14,5 +14,5 @@
         "on_library_management_file_test": 1
     },
     "tags": "library file test",
-    "version": "0.0.4"
+    "version": "0.0.5"
 }

--- a/source/limit_library_search_by_file_extension/plugin.py
+++ b/source/limit_library_search_by_file_extension/plugin.py
@@ -65,7 +65,9 @@ def file_ends_in_allowed_extensions(path, allowed_extensions):
     if not allowed_extensions:
         logger.debug("Plugin has not yet been configured with a list of file extensions to allow. Blocking everything.")
         return False
-
+    
+    # Remove Whitespace
+    allowed_extensions = "".join(allowed_extensions.split())
     # Check if it ends with one of the allowed search extensions
     if file_extension and file_extension in allowed_extensions.split(','):
         return True


### PR DESCRIPTION
Previously, putting multiple file extensions with commas and spaces would only check the first one. This makes it so that the behavior is the same whether you put spaces after the commas or not.