### PR TITLE
[extract_srt_subtitles_to_files] v0.0.13

### DIFF
--- a/source/extract_srt_subtitles_to_files/changelog.md
+++ b/source/extract_srt_subtitles_to_files/changelog.md
@@ -1,4 +1,8 @@
 
+**<span style="color:#56adda">0.0.13</span>**
+- add flag to extract untagged subtitle streams
+- fix bug that causes only the latest stream to survive when multiple streams have the same tag
+
 **<span style="color:#56adda">0.0.12</span>**
 - add back in file test check for presence of text subtitles
 - change text of what is written in .unmanic file to prevent against empty string in cases where remove all subtitles is run in same library

--- a/source/extract_srt_subtitles_to_files/info.json
+++ b/source/extract_srt_subtitles_to_files/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 2
     },
     "tags": "subtitle,ffmpeg",
-    "version": "0.0.12"
+    "version": "0.0.13"
 }

--- a/source/extract_srt_subtitles_to_files/plugin.py
+++ b/source/extract_srt_subtitles_to_files/plugin.py
@@ -64,6 +64,7 @@ class PluginStreamMapper(StreamMapper):
         super(PluginStreamMapper, self).__init__(logger, ['subtitle'])
         self.sub_streams = []
         self.settings = None
+        self.used_tags = {}
 
     def set_settings(self, settings):
         self.settings = settings
@@ -123,9 +124,29 @@ class PluginStreamMapper(StreamMapper):
         if title_tag and self.settings.get_setting('include_title_in_output_file_name'):
             subtitle_tag = "{}.{}".format(subtitle_tag, title_tag)
 
-        # If there were no tags, just number the file
+        # If there were no tags, just number the file with prefix `.`
         if not subtitle_tag:
-            subtitle_tag = "{}.{}".format(subtitle_tag, stream_info.get('index'))
+            subtitle_tag = ".{}".format(stream_info.get('index'))
+        else:
+            # It is possible that there are multiple streams with the same tag
+            # If the title is not included, the tags will be the same for all such
+            # streams and only the most recently extracted file will survive.
+            # We make it unique by adding a `.1` and `.2` to it. However, we do
+            # not add a `.1` is the tag is being used for the first time.
+            base_tag = subtitle_tag
+            if base_tag in self.used_tags:
+                self.used_tags[base_tag] += 1
+                # Used for the second time, so add 1 to the previous one
+                if self.used_tags[base_tag] == 2:
+                    for past_stream in self.sub_streams:
+                        if past_stream.get('subtitle_tag') == base_tag:
+                            past_stream['subtitle_tag'] = "{}.1".format(base_tag)
+                            break
+                # Add the number to the current tag
+                subtitle_tag = "{}.{}".format(base_tag, self.used_tags[base_tag])
+            else:
+                # First time seeing this tag
+                self.used_tags[base_tag] = 1
 
         # Ensure subtitle tag does not contain whitespace or slashes
         subtitle_tag = re.sub('\s|/|\\\\', '-', subtitle_tag)

--- a/source/extract_srt_subtitles_to_files/plugin.py
+++ b/source/extract_srt_subtitles_to_files/plugin.py
@@ -35,6 +35,7 @@ logger = logging.getLogger("Unmanic.Plugin.extract_srt_subtitles_to_files")
 class Settings(PluginSettings):
     settings = {
         "languages_to_extract": "",
+        "include_no_language_subtitles": True,
         "include_title_in_output_file_name": True
     }
 
@@ -45,10 +46,17 @@ class Settings(PluginSettings):
             "languages_to_extract": {
                 "label": "Subtitle languages to extract (leave empty for all)",
             },
+            "include_no_language_subtitles": {
+                "label": "Include subtitles with no language tag",
+            },
             "include_title_in_output_file_name": {
                 "label": "Include title in output file name",
             },
         }
+
+        # Hide 'include_no_language_subtitles' if 'languages_to_extract' is empty
+        if not self.get_setting('languages_to_extract'):
+            self.form_settings["include_no_language_subtitles"]["display"] = "hidden"
 
 
 class PluginStreamMapper(StreamMapper):
@@ -79,7 +87,11 @@ class PluginStreamMapper(StreamMapper):
         if len(languages) == 0:
             return True
 
-        language_tag = stream_info.get('tags').get('language', '').lower()
+        language_tag = stream_info.get('tags', {}).get('language', '').lower()
+
+        # If there is no language tag, check if we should include it
+        if not language_tag:
+            return self.settings.get_setting('include_no_language_subtitles')
 
         return language_tag in languages
 
@@ -93,12 +105,14 @@ class PluginStreamMapper(StreamMapper):
 
         languages = self._get_language_list()
 
-        # Skip stream
+        # Skip stream if it does not match the language list
         if len(languages) > 0 and language_tag not in languages:
-            return {
-                'stream_mapping':  [],
-                'stream_encoding': [],
-            }
+            # If there is no language tag, check if we should include it
+            if language_tag or not self.settings.get_setting('include_no_language_subtitles'):
+                return {
+                    'stream_mapping':  [],
+                    'stream_encoding': [],
+                }
 
         # Find a tag for this subtitle
         subtitle_tag = ''
@@ -269,45 +283,45 @@ def on_worker_process(data):
         settings = Settings(library_id=data.get('library_id'))
     else:
         settings = Settings()
-        
+
     if not srt_already_extracted(settings, data.get('file_in')):
         # Get stream mapper
         mapper = PluginStreamMapper()
-    
+
         mapper.set_settings(settings)
         mapper.set_probe(probe)
-    
+
         split_original_file_path = os.path.splitext(data.get('original_file_path'))
         original_file_directory = os.path.dirname(data.get('original_file_path'))
-    
+
         if mapper.streams_need_processing():
             # Set the input file
             mapper.set_input_file(abspath)
-    
+
             # Get generated ffmpeg args
             ffmpeg_args = mapper.get_ffmpeg_args()
-    
+
             # Append STR extract args
             for sub_stream in mapper.sub_streams:
                 stream_mapping = sub_stream.get('stream_mapping', [])
                 subtitle_tag = sub_stream.get('subtitle_tag')
-    
+
                 ffmpeg_args += stream_mapping
                 ffmpeg_args += [
                     "-y",
                     os.path.join(original_file_directory, "{}{}.srt".format(split_original_file_path[0], subtitle_tag)),
                 ]
-    
+
             # Apply ffmpeg args to command
             data['exec_command'] = ['ffmpeg']
             data['exec_command'] += ffmpeg_args
-    
+
             # Set the parser
             parser = Parser(logger)
             parser.set_probe(probe)
             data['command_progress_parser'] = parser.parse_progress
     return data
-    
+
 def on_postprocessor_task_results(data):
     """
     Runner function - provides a means for additional postprocessor functions based on the task success.
@@ -341,7 +355,7 @@ def on_postprocessor_task_results(data):
         probe_streams=probe_data.get_probe()["streams"]
     else:
         probe_streams=[]
-        
+
     # Loop over the destination_files list and update the directory info file for each one
     for destination_file in data.get('destination_files'):
         langs = ""
@@ -358,4 +372,4 @@ def on_postprocessor_task_results(data):
         directory_info.save()
         logger.info("SRT subtitles processed for '{}' and recorded in .unmanic file.".format(destination_file))
 
-    return data                                                                                
+    return data


### PR DESCRIPTION
### feat(extract-srt): include missing lang tags

If the value of subtitle languages to extract is empty, this option is not
visible.
<img width="407" height="151" alt="image" src="https://github.com/user-attachments/assets/44451819-6342-42d6-a2ce-b3c925e2b6e8" />

If, however, the previous setting is set, this option shows up.
<img width="315" height="211" alt="image" src="https://github.com/user-attachments/assets/eb44dc3c-6f47-4efd-81b9-5dc11c55450c" />

Here is an example of such a stream missing the language tag
```json
{
  "avg_frame_rate": "0/0",
  "codec_long_name": "SubRip subtitle",
  "codec_name": "subrip",
  "codec_tag": "0x0000",
  "codec_tag_string": "[0][0][0][0]",
  "codec_type": "subtitle",
  "disposition": {
    "attached_pic": 0,
    "captions": 0,
    "clean_effects": 0,
    "comment": 0,
    "default": 1,
    "dependent": 0,
    "descriptions": 0,
    "dub": 0,
    "forced": 0,
    "hearing_impaired": 0,
    "karaoke": 0,
    "lyrics": 0,
    "metadata": 0,
    "multilayer": 0,
    "non_diegetic": 0,
    "original": 0,
    "still_image": 0,
    "timed_thumbnails": 0,
    "visual_impaired": 0
  },
  "duration": "1424.598000",
  "duration_ts": 1424598,
  "index": 1,
  "r_frame_rate": "0/0",
  "start_pts": 0,
  "start_time": "0.000000",
  "tags": {
    "_STATISTICS_TAGS-eng": "BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES",
    "_STATISTICS_WRITING_APP-eng": "mkvmerge v44.0.0 ('Domino') 64-bit",
    "_STATISTICS_WRITING_DATE_UTC-eng": "2020-07-22 07:57:37",
    "BPS-eng": "56",
    "DURATION-eng": "00:21:28.649000000",
    "NUMBER_OF_BYTES-eng": "9042",
    "NUMBER_OF_FRAMES-eng": "275"
  },
  "time_base": "1/1000"
}
```

### fix(extract-srt): make subtitle tags unique
    
When there are multiple streams bearing the same tags (whether due to
being embedded as such in `mediainfo` or due to the user's settings),
only the most-recently extracted stream would survive. This change fixes
that issue by adding a counter to all extracted files bearing the same
tag