### PR TITLE
[ignore_video_file_under_size] v0.0.4: fix NoneType crash + dead extension fallback

### DIFF
--- a/source/ignore_video_file_under_size/changelog.md
+++ b/source/ignore_video_file_under_size/changelog.md
@@ -1,4 +1,8 @@
 
+**<span style="color:#56adda">0.0.4</span>**
+- Fix TypeError crash when mimetypes.guess_type() returns None (unknown extensions, or a thread race against another plugin's mimetypes.init() during concurrent library scans)
+- Fix known-video-extension fallback never matching (os.path.splitext() returns extensions with a leading dot)
+
 **<span style="color:#56adda">0.0.3</span>**
 - add option to read duration from format section of ffprobe output
 

--- a/source/ignore_video_file_under_size/info.json
+++ b/source/ignore_video_file_under_size/info.json
@@ -15,5 +15,5 @@
         "on_library_management_file_test": 2
     },
     "tags": "library file test",
-    "version": "0.0.3"
+    "version": "0.0.4"
 }

--- a/source/ignore_video_file_under_size/plugin.py
+++ b/source/ignore_video_file_under_size/plugin.py
@@ -154,8 +154,11 @@ def on_library_management_file_test(data):
     file_path = data.get('path')
     logger.debug("Checking file %s", file_path)
     file_mime_type = mimetypes.guess_type(file_path)[0]
-    if "video" not in file_mime_type:
-        file_extension = os.path.splitext(file_path)[1]
+    # guess_type() can return None (unknown extension, or racing another
+    # thread's mimetypes.init()) - crashing on it would abort the whole
+    # file-test chain for this file.
+    if not file_mime_type or "video" not in file_mime_type:
+        file_extension = os.path.splitext(file_path)[1].lstrip(".").lower()
         if file_extension in ["mkv", "mp4", "mov", "avi", "wmv", "flv", "avchd"]:
             raise AssertionError(f"File {file_path} was a known video type "
                                  f"but mime type was {file_mime_type} was not recognized")


### PR DESCRIPTION
## Problem

Two bugs in `on_library_management_file_test`:

1. **`TypeError: argument of type 'NoneType' is not iterable`** — `mimetypes.guess_type()` returns `None` for unknown extensions (e.g. transient `.unmanic.part` files during post-processing), and can also return `None` for *valid* media files when racing another plugin's `mimetypes.init()` call on Unmanic's concurrent file-tester threads (see Josh5/unmanic.plugin.helpers.ffmpeg#7 — the vendored helper lib re-inits the global mimetypes database on every `Probe()`). The crash aborts this plugin's file test for that file on every scan.

2. **Dead fallback branch** — `os.path.splitext()` returns extensions with a leading dot (`".mp4"`), so membership in the dot-less list `["mkv", "mp4", ...]` never matches, and the known-video-extension check is unreachable.

## Fix

- Treat a `None` mimetype like any other non-video mimetype instead of crashing.
- Normalise the extension (`.lstrip(".").lower()`) so the fallback works as intended.

Version bumped to 0.0.4 with changelog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
