### PR TITLE
[reject_files_larger_than_original] v0.0.5: optional size tolerance

### DIFF
--- a/source/reject_files_larger_than_original/changelog.md
+++ b/source/reject_files_larger_than_original/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.5</span>**
+- Add an optional size tolerance (default 0%% = unchanged behaviour). Without it, remux-style tasks that grow a file by a few bytes (eg. hev1->hvc1 codec-tag rewrites with '-movflags +faststart') are rejected and recorded as successful no-ops, permanently blocking the intended change for plugins like 'Ignore completed tasks'
+
 **<span style="color:#56adda">0.0.4</span>**
 - Improve workflow to remove additional file movements
 - Update Plugin to remove Unmanic v1 PluginHandler compatibility

--- a/source/reject_files_larger_than_original/info.json
+++ b/source/reject_files_larger_than_original/info.json
@@ -12,9 +12,9 @@
     ],
     "priorities": {
         "on_library_management_file_test": 2,
-        "on_worker_process": 2,
-        "on_postprocessor_file_movement": 5
+        "on_postprocessor_file_movement": 5,
+        "on_worker_process": 2
     },
     "tags": "library file test",
-    "version": "0.0.4"
+    "version": "0.0.5"
 }

--- a/source/reject_files_larger_than_original/plugin.py
+++ b/source/reject_files_larger_than_original/plugin.py
@@ -39,6 +39,7 @@ class Settings(PluginSettings):
     settings = {
         'fail_task_if_file_detected_larger':                 False,
         'if_end_result_file_is_still_larger_mark_as_ignore': False,
+        'tolerance_percent':                                 0,
     }
     form_settings = {
         "fail_task_if_file_detected_larger":                 {
@@ -47,7 +48,32 @@ class Settings(PluginSettings):
         "if_end_result_file_is_still_larger_mark_as_ignore": {
             "label": "Ignore files in future scans if end result is larger than source (regardless of task history)",
         },
+        "tolerance_percent":                                 {
+            "label":          "Tolerance (%) - allow the new file to be up to this much larger before rejecting it",
+            "input_type":     "slider",
+            "slider_options": {
+                "min":  0,
+                "max":  10,
+                "step": 0.5,
+            },
+        },
     }
+
+
+def get_size_limit(settings, original_size):
+    """
+    Return the maximum acceptable size for the new file.
+
+    A small tolerance allows container-level operations that add a few bytes
+    (eg. an MP4 remux with '-movflags +faststart' relocating the moov atom,
+    or a codec-tag rewrite) to succeed rather than being rejected over an
+    insignificant size increase.
+    """
+    try:
+        tolerance_percent = float(settings.get_setting('tolerance_percent') or 0)
+    except (TypeError, ValueError):
+        tolerance_percent = 0
+    return int(original_size) * (1 + (tolerance_percent / 100))
 
 
 def file_marked_as_failed(settings, path):
@@ -145,7 +171,7 @@ def on_worker_process(data):
     original_file_stats = os.stat(os.path.join(original_file_path))
 
     # Test that the source file is not smaller than the new file
-    if int(current_file_stats.st_size) > int(original_file_stats.st_size):
+    if int(current_file_stats.st_size) > get_size_limit(settings, original_file_stats.st_size):
         if settings.get_setting('fail_task_if_file_detected_larger'):
             # Add some worker logs to be transparent as to what is happening
             if data.get('worker_log'):
@@ -226,7 +252,7 @@ def on_postprocessor_file_movement(data):
         original_file_stats = os.stat(os.path.join(original_source_path))
 
         # Test that the source file is not smaller than the new file
-        if int(current_file_stats.st_size) > int(original_file_stats.st_size):
+        if int(current_file_stats.st_size) > get_size_limit(settings, original_file_stats.st_size):
             # The current file is larger than the original.
             # Mark it as failed
             write_file_marked_as_failed(original_source_path)


### PR DESCRIPTION
## Problem

The strict `>` size comparison interacts badly with remux-style worker tasks. Example from a real library: Apple HEVC's hev1→hvc1 codec-tag rewrite (`-c:v copy -tag:v:0 hvc1 -movflags +faststart`) relocates the moov atom and made a 476,042,676-byte file **39 bytes** larger. This plugin rejected the result and reset the source file — but the task still completed "successful".

That combination is worse than a no-op: with "Ignore completed tasks" enabled (or this plugin's own ignore option), the file is now permanently blocked from ever receiving its intended change, and the rejection is invisible unless you read the task log. In our case ~50 remuxes per hour were being silently nullified this way.

## Fix

Add an optional **tolerance** slider (percent, default **0** — behaviour completely unchanged unless the user opts in). With e.g. 1%, container-overhead growth passes while genuinely larger encodes (typically +10–30%) are still rejected.

Version bumped to 0.0.5 with a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
