### PR TITLE
[apple_hevc] v0.0.2: fix file-test crash on failed probe + mimetypes thread race

### DIFF
--- a/source/apple_hevc/changelog.md
+++ b/source/apple_hevc/changelog.md
@@ -1,3 +1,7 @@
 
+**<span style="color:#56adda">0.0.2</span>**
+- Fix file test crashing with AttributeError when the file probe fails (Probe.init_probe returns None)
+- Fix thread race: only call mimetypes.init() once (concurrent library-scan file testers could see guess_type() return None for valid files, silently skipping them)
+
 **<span style="color:#56adda">0.0.1</span>**
 - initial version

--- a/source/apple_hevc/info.json
+++ b/source/apple_hevc/info.json
@@ -11,5 +11,5 @@
         "on_worker_process": 0
     },
     "tags": "apple, mac, hvc1, hev1, hevc, 265",
-    "version": "0.0.1"
+    "version": "0.0.2"
 }

--- a/source/apple_hevc/lib/ffmpeg/probe.py
+++ b/source/apple_hevc/lib/ffmpeg/probe.py
@@ -114,8 +114,12 @@ class Probe(object):
             allowed_mimetypes = ['audio', 'video', 'image']
         self.allowed_mimetypes = allowed_mimetypes
 
-        # Init (reset) our mimetype list
-        mimetypes.init()
+        # Init our mimetype list only once. mimetypes.init() rebuilds the module's
+        # GLOBAL database, so calling it on every Probe() instantiation from
+        # concurrent file-tester threads races guess_type() in other threads into
+        # returning None for valid media files.
+        if not mimetypes.inited:
+            mimetypes.init()
 
         # Add mimetype overrides to mimetype dictionary (replaces any existing entries)
         mimetype_overrides = MimetypeOverrides()

--- a/source/apple_hevc/plugin.py
+++ b/source/apple_hevc/plugin.py
@@ -98,7 +98,7 @@ def on_library_management_file_test(data):
 
     # Get file probe
     probe = Probe.init_probe(data, logger)
-    if not probe.file(abspath):
+    if not probe or not probe.file(abspath):
         # File probe failed, skip the rest of this test
         return data
 


### PR DESCRIPTION
## Problem

The vendored apple_hevc here is v0.0.1, whose library-management file test crashes whenever the file probe fails: `Probe.init_probe()` returns `None` on a failed probe and the plugin dereferences it (`AttributeError: 'NoneType' object has no attribute 'file'`). Each crash aborts the entire file-test chain for that file, so subsequent plugins never run on it either.

The probes fail more than you'd expect, because of a thread race in the vendored ffmpeg helper lib: `Probe.__init__` calls `mimetypes.init()` on every instantiation, rebuilding Python's **global** mimetype database — and Unmanic runs file tests on several concurrent tester threads, so other threads' `guess_type()` calls race the rebuild and get `None` for valid mp4 files. Observed on a live library: 168 crashes in a single scan; ~160 hev1 mp4s silently never queued for their hvc1 remux, clustered by directory (thread timing).

## Fix

- Guard the `init_probe` result before use — this mirrors the fix the plugin author committed to their development repo (k29t59dh/unmanic-plugins@0e41183, also proposed for release in k29t59dh/unmanic-plugins#1) which never shipped here. The worker-stage call site constructs `Probe` directly and is unaffected.
- Guard `mimetypes.init()` with `mimetypes.inited` in the vendored lib (same fix proposed for the shared helper repo in Josh5/unmanic.plugin.helpers.ffmpeg#7).
- Version 0.0.2 + changelog.

**Testing:** verified against Unmanic `0.4.0+e838573` (`josh5/unmanic:latest`), 4 concurrent file testers + 3 QSV workers: all previously-skipped hev1 mp4s queue correctly and remux to hvc1 (ffprobe-verified). No new python files introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
